### PR TITLE
update docker-compose to add RAM mount for transcode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - /etc/localtime:/etc/localtime:ro  # Use host timezone for EPG
       # For HTTPS, also mount your certificates:
       # - /etc/letsencrypt:/etc/letsencrypt:ro
-      # For system RAM instead of using local storage
+      # Use system RAM instead of using local storage to store transcodes
       # - /dev/shm:/tmp
     restart: unless-stopped
     # Hardware acceleration (Intel/AMD) - comment out if no /dev/dri


### PR DESCRIPTION
Added a comment in the docker-compose.yml to with a note for mounting /dev/shm inside container at /tmp to allow for transcode to be written to RAM instead of hitting the local storage on your docker host.