### PR TITLE
fix group/user add commands to enable VAAPI

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,8 +14,9 @@ fi
 # Add netv user to render device group (for VAAPI hardware encoding)
 if [ -e /dev/dri/renderD128 ]; then
     RENDER_GID=$(stat -c '%g' /dev/dri/renderD128)
-    addgroup --gid "$RENDER_GID" hostrender 2>/dev/null || true
-    adduser netv hostrender 2>/dev/null || true
+    groupadd --gid "$RENDER_GID" hostrender 2>/dev/null || true
+    useradd netv 2>/dev/null || true
+    usermod -g hostrender netv 2>/dev/null || true
 fi
 
 # Drop to netv user and run the app


### PR DESCRIPTION
Doing the following fixed the greyed-out radio button for 'Intel/AMD (VA-API)' in the neTV UI

1. The `addgroup` command doesn't exist. I assume this should be `groupadd`
2. The `adduser` command doesn't exist. I assume this should be `useradd`
3. I assume the `useradd` command is supposed to add the `hostrender` group to the `netv` user. I've added a `useradd` line alone followed by a `usermod` to put `netv` in the `hostrender` group


```
# docker exec -it netv /bin/bash
root@786218c40885:/app# egrep 'netv|hostrender' /etc/group
netv:x:1001:
hostrender:x:993:
```
```
root@786218c40885:/app# egrep 'netv|hostrender' /etc/passwd
netv:x:1001:993::/home/netv:/bin/sh
```
```
root@786218c40885:/app# groups netv
netv : hostrender
```
```
2026-01-04T21:56:30.505588078Z 15:56:30 | INFO | Detecting hardware encoders...
2026-01-04T21:56:30.542905037Z 15:56:30 | INFO |   NVIDIA (h264_nvenc): unavailable - [h264_nvenc @ 0x60fa43737780] Cannot load libcuda.so.1
2026-01-04T21:56:30.542947832Z [vost#0:0/h264_nvenc @ 0x60fa43737100] [enc:h264_nvenc @ 0x60fa43737700] Error while opening encoder - maybe incorrect parameters such as bit_rate, rate, width or height.
2026-01-04T21:56:30.542957653Z [vf#0:0 @ 0x60fa437527c0] Error sending frames to consumers: Operation not permitted
2026-01-04T21:56:30.542964911Z [vf#0:0 @ 0x60fa437527c0] Task finished with error code: -1 (Operation not permitted)
2026-01-04T21:56:30.542972587Z [vf#0:0 @ 0x60fa437527c0] Terminating thread with return code -1 (Operation not permitted)
2026-01-04T21:56:30.542979624Z [vost#0:0/h264_nvenc @ 0x60fa43737100] [enc:h264_nvenc @ 0x60fa43737700] Could not open encoder before EOF
2026-01-04T21:56:30.542986499Z [vost#0:0/h264_nvenc @ 0x60fa43737100] Task finished with error code: -22 (Invalid argument)
2026-01-04T21:56:30.542993364Z [vost#0:0/h264_nvenc @ 0x60fa43737100] Terminating thread with return code -22 (Invalid argument)
2026-01-04T21:56:30.543000741Z [out#0/null @ 0x60fa43736d80] Nothing was written into output file, because at least one of its streams received no packets.
2026-01-04T21:56:30.567626510Z 15:56:30 | INFO |   Intel (h264_qsv): unavailable - Device creation failed: -1313558101.
2026-01-04T21:56:30.588023053Z 15:56:30 | INFO |   VA-API (h264_vaapi): available
2026-01-04T21:56:30.603798455Z 15:56:30 | INFO |   Software (libx264): available
```