### PR TITLE
Fix HLS streams with special characters in credentials

### DIFF
--- a/ffmpeg_command.py
+++ b/ffmpeg_command.py
@@ -534,6 +534,9 @@ def probe_media(
             "json",
             "-show_streams",
             "-show_format",
+            # Allow HLS segments without standard extensions (some IPTV providers use token URLs)
+            "-extension_picky",
+            "0",
         ]
         user_agent = get_user_agent()
         if user_agent:
@@ -957,6 +960,8 @@ def build_hls_ffmpeg_cmd(
     )
     if user_agent:
         cmd.extend(["-user_agent", user_agent])
+    # Allow HLS segments without standard extensions (some IPTV providers use token URLs)
+    cmd.extend(["-extension_picky", "0"])
     cmd.extend(["-i", input_url])
 
     # Subtitle extraction

--- a/main.py
+++ b/main.py
@@ -1221,6 +1221,9 @@ def _get_live_player_info(stream_id: str) -> PlayerInfo:
     elif stream.get("source_type") == "xtream":
         base, user, pwd = stream["source_url"], stream["source_username"], stream["source_password"]
         orig_id = stream_id.split("_")[-1] if "_" in stream_id else stream_id
+        # URL-encode username/password to handle special chars like # in passwords
+        user = urllib.parse.quote(user, safe='')
+        pwd = urllib.parse.quote(pwd, safe='')
         info.url = f"{base}/live/{user}/{pwd}/{orig_id}.m3u8"
 
     # Look up source settings

--- a/xtream.py
+++ b/xtream.py
@@ -86,7 +86,10 @@ class XtreamClient:
         return self._api("get_short_epg", stream_id=stream_id, limit=limit)
 
     def build_stream_url(self, stream_type: str, stream_id: int, ext: str = "") -> str:
-        base = f"{self.base_url}/{stream_type}/{self.username}/{self.password}/{stream_id}"
+        # URL-encode username/password to handle special chars like # in passwords
+        user = urllib.parse.quote(self.username, safe='')
+        pwd = urllib.parse.quote(self.password, safe='')
+        base = f"{self.base_url}/{stream_type}/{user}/{pwd}/{stream_id}"
         return f"{base}.{ext}" if ext else base
 
     def build_timeshift_url(
@@ -97,8 +100,11 @@ class XtreamClient:
         ext: str = "ts",
     ) -> str:
         """For streams with tv_archive=1. start format: YYYY-MM-DD:HH-MM."""
+        # URL-encode username/password to handle special chars like # in passwords
+        user = urllib.parse.quote(self.username, safe='')
+        pwd = urllib.parse.quote(self.password, safe='')
         return (
-            f"{self.base_url}/timeshift/{self.username}/{self.password}/"
+            f"{self.base_url}/timeshift/{user}/{pwd}/"
             f"{duration}/{start}/{stream_id}.{ext}"
         )
 


### PR DESCRIPTION
Fixes #36

- URL-encode username/password in stream URLs
- Add `-extension_picky 0` to ffprobe/ffmpeg for token-based segment URLs