### PR TITLE
Add virtual scrolling to TV guide for large channel lists

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ import time
 import urllib.error
 import urllib.parse
 
-from fastapi import Depends, FastAPI, Form, HTTPException, Request
+from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -625,9 +625,85 @@ async def guide_page(
             )
 
     categories = get_cache()["live_categories"]
-    all_streams = get_cache()["live_streams"]
     # EPG is optional - check sqlite db for data
     epg_loading = not epg.has_programs()
+
+    # Get the full saved filter for dropdown (not just current URL filter)
+    user_settings = load_user_settings(username)
+    saved_filter = set(user_settings.get("guide_filter", []))
+
+    # Use helper to get filtered/sorted streams
+    streams, ordered_cats, selected_cats = _get_guide_streams(cats, username)
+    total_count = len(streams)
+
+    # Time window: 3 hours starting from offset
+    now = datetime.now(UTC)
+    window_start = now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=offset)
+    window_end = window_start + timedelta(hours=3)
+
+    # Virtual scrolling: only render first batch (130 rows)
+    # JS will handle fetching more as user scrolls
+    initial_batch_size = 130
+    grid_data = _build_guide_rows(
+        streams, 0, initial_batch_size, window_start, window_end
+    )
+
+    # Time markers (every 30 min) - convert to local time for display
+    time_markers = []
+    for i in range(7):  # 0, 30, 60, 90, 120, 150, 180 minutes
+        t = window_start + timedelta(minutes=i * 30)
+        t_local = t.astimezone()  # Convert to local timezone
+        time_markers.append(
+            {
+                "label": t_local.strftime("%H:%M"),
+                "left_pct": (i * 30 / 180) * 100,
+            }
+        )
+
+    # Mobile time markers (2 hour window instead of 3)
+    time_markers_mobile = []
+    for i in range(5):  # 0, 30, 60, 90, 120 minutes
+        t = window_start + timedelta(minutes=i * 30)
+        t_local = t.astimezone()
+        time_markers_mobile.append(
+            {
+                "label": t_local.strftime("%H:%M"),
+                "left_pct": (i * 30 / 120) * 100,
+            }
+        )
+
+    return TEMPLATES.TemplateResponse(
+        request,
+        "guide.html",
+        {
+            "categories": categories,
+            "selected_cats": selected_cats,
+            "saved_filter": saved_filter,  # Full saved filter for dropdown
+            "cats_param": cats,
+            "grid_data": grid_data,
+            "time_markers": time_markers,
+            "time_markers_mobile": time_markers_mobile,
+            "offset": offset,
+            "window_start": window_start.strftime("%Y-%m-%d %H:%M"),
+            "epg_error": get_cache().get("epg_error"),
+            "epg_loading": epg_loading,
+            "channel_count": len(grid_data),
+            "total_count": total_count,  # For virtual scrolling
+            "loading": False,
+            "content_access": _get_content_access(username),
+        },
+    )
+
+
+def _get_guide_streams(
+    cats: str, username: str
+) -> tuple[list[dict], list[str], set[str]]:
+    """Get filtered and sorted streams for guide.
+
+    Returns:
+        Tuple of (filtered_streams, ordered_cat_ids, selected_cat_set)
+    """
+    all_streams = get_cache().get("live_streams", [])
 
     # Parse selected category IDs (ordered list)
     ordered_cats: list[str] = []
@@ -635,54 +711,65 @@ async def guide_page(
         ordered_cats = [c.strip() for c in cats.split(",") if c.strip()]
     selected_cats = set(ordered_cats)
 
+    if not selected_cats:
+        return [], ordered_cats, selected_cats
+
     # Get user's unavailable groups for filtering
     user_limits = auth.get_user_limits(username)
     unavailable_groups = set(user_limits.get("unavailable_groups", []))
 
-    # Filter and sort streams by category order
-    if selected_cats:
-        cat_order = {c: i for i, c in enumerate(ordered_cats)}
+    cat_order = {c: i for i, c in enumerate(ordered_cats)}
 
-        def stream_sort_key(s: dict) -> int:
-            for c in s.get("category_ids") or []:
-                if str(c) in cat_order:
-                    return cat_order[str(c)]
-            return len(ordered_cats)
+    def stream_sort_key(s: dict) -> int:
+        for c in s.get("category_ids") or []:
+            if str(c) in cat_order:
+                return cat_order[str(c)]
+        return len(ordered_cats)
 
-        def stream_allowed(s: dict) -> bool:
-            """Check if stream is allowed (not in any unavailable group)."""
-            cat_ids = s.get("category_ids") or []
-            # Stream is blocked if ANY of its categories are unavailable
-            return not any(f"cat:{c}" in unavailable_groups for c in cat_ids)
+    def stream_allowed(s: dict) -> bool:
+        cat_ids = s.get("category_ids") or []
+        return not any(f"cat:{c}" in unavailable_groups for c in cat_ids)
 
-        streams = [
-            s
-            for s in all_streams
-            if any(str(c) in selected_cats for c in (s.get("category_ids") or []))
-            and stream_allowed(s)
-        ]
-        streams.sort(key=stream_sort_key)
-    else:
-        streams = []
+    streams = [
+        s
+        for s in all_streams
+        if any(str(c) in selected_cats for c in (s.get("category_ids") or []))
+        and stream_allowed(s)
+    ]
+    streams.sort(key=stream_sort_key)
 
-    # Build channel list with EPG IDs
+    return streams, ordered_cats, selected_cats
+
+
+def _build_guide_rows(
+    streams: list[dict],
+    start_idx: int,
+    count: int,
+    window_start: datetime,
+    window_end: datetime,
+) -> list[dict]:
+    """Build guide grid rows for a range of streams.
+
+    Returns:
+        List of row dicts with channel info and programs.
+    """
+    end_idx = min(start_idx + count, len(streams))
+    slice_streams = streams[start_idx:end_idx]
+
+    if not slice_streams:
+        return []
+
     # Collect EPG IDs for batch query
-    epg_ids = [s.get("epg_channel_id") or "" for s in streams]
+    epg_ids = [s.get("epg_channel_id") or "" for s in slice_streams]
     epg_ids_set = [e for e in epg_ids if e]
 
     # Batch fetch icons and programs
     icons_map = epg.get_icons_batch(epg_ids_set) if epg_ids_set else {}
 
-    # Time window: 3 hours starting from offset
-    now = datetime.now(UTC)
-    window_start = now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=offset)
-    window_end = window_start + timedelta(hours=3)
-
-    # Build preferred_sources: map epg_channel_id -> stream's source_id
-    # This prefers EPG from the same source as the channel (e.g., HDHomeRun EPG for HDHomeRun channels)
+    # Build preferred_sources for EPG matching
     preferred_sources = {
         epg_id: s.get("source_id", "")
-        for s, epg_id in zip(streams, epg_ids, strict=False)
+        for s, epg_id in zip(slice_streams, epg_ids, strict=False)
         if epg_id and s.get("source_id")
     }
     programs_map = (
@@ -691,19 +778,13 @@ async def guide_page(
         else {}
     )
 
-    # Log streams with EPG IDs that returned no programs (potential misconfiguration)
-    for s, epg_id in zip(streams, epg_ids, strict=False):
-        if epg_id and not programs_map.get(epg_id):
-            log.warning(
-                "Stream '%s' has epg_channel_id='%s' but no EPG programs found",
-                s["name"],
-                epg_id,
-            )
-
-    # Build channel list and grid data
+    # Build rows
     window_end_mobile = window_start + timedelta(hours=2)
     grid_data = []
-    for s, epg_id in zip(streams, epg_ids, strict=False):
+
+    for idx, (s, epg_id) in enumerate(
+        zip(slice_streams, epg_ids, strict=False), start=start_idx
+    ):
         icon = s.get("stream_icon", "") or icons_map.get(epg_id, "")
         ch = {
             "stream_id": s["stream_id"],
@@ -711,7 +792,8 @@ async def guide_page(
             "icon": icon,
             "epg_id": epg_id,
         }
-        row = {"channel": ch, "programs": [], "programs_mobile": []}
+        row = {"channel": ch, "programs": [], "programs_mobile": [], "index": idx}
+
         for p in programs_map.get(epg_id, []):
             p_start = max(p.start, window_start)
             p_end = min(p.stop, window_end)
@@ -745,51 +827,56 @@ async def guide_page(
                         "width_pct": width_pct_m,
                     }
                 )
+
         grid_data.append(row)
 
-    # Time markers (every 30 min) - convert to local time for display
-    time_markers = []
-    for i in range(7):  # 0, 30, 60, 90, 120, 150, 180 minutes
-        t = window_start + timedelta(minutes=i * 30)
-        t_local = t.astimezone()  # Convert to local timezone
-        time_markers.append(
-            {
-                "label": t_local.strftime("%H:%M"),
-                "left_pct": (i * 30 / 180) * 100,
-            }
-        )
+    return grid_data
 
-    # Mobile time markers (2 hour window instead of 3)
-    time_markers_mobile = []
-    for i in range(5):  # 0, 30, 60, 90, 120 minutes
-        t = window_start + timedelta(minutes=i * 30)
-        t_local = t.astimezone()
-        time_markers_mobile.append(
-            {
-                "label": t_local.strftime("%H:%M"),
-                "left_pct": (i * 30 / 120) * 100,
-            }
-        )
 
-    return TEMPLATES.TemplateResponse(
-        request,
-        "guide.html",
-        {
-            "categories": categories,
-            "selected_cats": selected_cats,
-            "cats_param": cats,
-            "grid_data": grid_data,
-            "time_markers": time_markers,
-            "time_markers_mobile": time_markers_mobile,
-            "offset": offset,
-            "window_start": window_start.strftime("%Y-%m-%d %H:%M"),
-            "epg_error": get_cache().get("epg_error"),
-            "epg_loading": epg_loading,
-            "channel_count": len(grid_data),
-            "loading": False,
-            "content_access": _get_content_access(username),
-        },
+@app.get("/api/guide/rows")
+async def guide_rows_api(
+    user: Annotated[dict, Depends(require_auth)],
+    start: int = Query(default=0, ge=0, description="Starting row index"),
+    count: int = Query(default=130, ge=1, le=500, description="Number of rows to fetch"),
+    offset: int = Query(default=0, ge=-168, le=168, description="Hours offset from now"),
+    cats: str = "",
+):
+    """API endpoint for virtual scrolling - returns guide rows as JSON."""
+    username = user.get("sub", "")
+
+    # Use saved filter if no cats provided
+    if not cats:
+        user_settings = load_user_settings(username)
+        saved = user_settings.get("guide_filter", [])
+        if saved:
+            cats = ",".join(saved)
+
+    # Ensure data is loaded
+    if "live_streams" not in get_cache():
+        cached = await asyncio.to_thread(load_file_cache, "live_data")
+        if cached:
+            data, _ = cached
+            with get_cache_lock():
+                get_cache()["live_categories"] = data["cats"]
+                get_cache()["live_streams"] = data["streams"]
+                get_cache()["epg_urls"] = parse_epg_urls(data.get("epg_urls", []))
+
+    streams, _, _ = _get_guide_streams(cats, username)
+    total_count = len(streams)
+
+    if total_count == 0:
+        return JSONResponse({"rows": [], "total": 0, "start": start})
+
+    # Time window
+    now = datetime.now(UTC)
+    window_start = now.replace(minute=0, second=0, microsecond=0) + timedelta(
+        hours=offset
     )
+    window_end = window_start + timedelta(hours=3)
+
+    rows = _build_guide_rows(streams, start, count, window_start, window_end)
+
+    return JSONResponse({"rows": rows, "total": total_count, "start": start})
 
 
 def _start_vod_background_load() -> None:

--- a/static/js/virtual-guide.js
+++ b/static/js/virtual-guide.js
@@ -1,0 +1,616 @@
+/**
+ * Virtual scrolling for the TV guide.
+ * Only renders rows that are visible (plus buffer), fetches more as needed.
+ */
+
+// Configuration constants
+const VIRTUAL_GUIDE_DEFAULTS = {
+  ROW_HEIGHT_DESKTOP: 64,       // 4rem in pixels
+  ROW_HEIGHT_MOBILE: 40,        // 2.5rem in pixels
+  BUFFER_SIZE: 50,              // Rows to load above/below viewport
+  MAX_CACHE_SIZE: 500,          // Evict cache beyond this
+  MAX_RETRIES: 3,               // Retry failed fetches this many times
+  MOBILE_BREAKPOINT: 512,       // Width below which is considered mobile
+  SCROLL_DIRECTION_THRESHOLD: 5, // Min scroll delta to register direction
+  RENDER_DEBOUNCE_MS: 16,       // ~60fps for smooth visual update
+  FETCH_DEBOUNCE_MS: 150,       // Wait for scroll to settle before fetching
+  RESIZE_DEBOUNCE_MS: 100,      // Debounce window resize handler
+};
+
+class VirtualGuide {
+  constructor(options) {
+    const D = VIRTUAL_GUIDE_DEFAULTS;
+
+    this.container = options.container;
+    this.rowHeight = options.rowHeight || D.ROW_HEIGHT_DESKTOP;
+    this.rowHeightMobile = options.rowHeightMobile || D.ROW_HEIGHT_MOBILE;
+    this.totalRows = options.totalRows;
+    this.bufferSize = options.bufferSize || D.BUFFER_SIZE;
+    this.maxCacheSize = options.maxCacheSize || D.MAX_CACHE_SIZE;
+    this.initialRows = options.initialRows || [];
+    this.offset = options.offset || 0;
+    this.cats = options.cats || '';
+    this.logoUrlFilter = options.logoUrlFilter || (url => url);
+
+    // State
+    this.cache = new Map(); // row index -> row data
+    this.failedRanges = new Map(); // range key -> retry count
+    this.maxRetries = D.MAX_RETRIES;
+    this.needsRecheck = false;
+    this.renderedRange = { start: 0, end: 0 };
+    this.pendingFetch = null;
+    this.pendingFetchRange = null;
+    this.scrollDebounce = null;
+    this.fetchDebounce = null;
+    this.renderDebounce = null;
+    this.recheckTimeout = null;
+    this.isMobile = window.innerWidth < D.MOBILE_BREAKPOINT;
+    this.lastScrollTop = 0;
+    this.scrollDirection = 'down';
+
+    // DOM elements
+    this.viewport = null;
+    this.content = null;
+    this.spacer = null;
+
+    this.init();
+  }
+
+  get currentRowHeight() {
+    return this.isMobile ? this.rowHeightMobile : this.rowHeight;
+  }
+
+  get visibleCount() {
+    if (!this.viewport) return 30;
+    return Math.ceil(this.viewport.clientHeight / this.currentRowHeight) + 1;
+  }
+
+  init() {
+    // Cache initial SSR rows
+    for (const row of this.initialRows) {
+      this.cache.set(row.index, row);
+    }
+
+    // Set up virtual scroll container
+    this.setupDOM();
+    this.bindEvents();
+
+    // Handle scroll position restoration
+    // Check if there's a saved scroll position that's beyond initial rows
+    const scrollKey = 'guide_scroll';
+    const savedScroll = sessionStorage.getItem(scrollKey);
+
+    if (savedScroll && this.viewport) {
+      const scrollTop = parseInt(savedScroll);
+      const firstVisible = Math.floor(scrollTop / this.currentRowHeight);
+
+      // If saved position is beyond initial batch, fetch first then scroll
+      if (firstVisible >= this.initialRows.length) {
+        // Fetch data for the saved position, then restore scroll
+        const start = Math.max(0, firstVisible - this.bufferSize);
+        const end = Math.min(this.totalRows, firstVisible + this.visibleCount + this.bufferSize);
+
+        this.fetchMissingRanges([{ start, end }]).then(() => {
+          this.viewport.scrollTop = scrollTop;
+          this.renderedRange = { start, end };
+          this.render();
+        });
+        return; // Don't do normal init flow
+      }
+    }
+
+    // If we have more rows than initial batch, enable virtual scrolling
+    if (this.totalRows > this.initialRows.length) {
+      this.updateVisibleRange();
+    }
+  }
+
+  setupDOM() {
+    // Find the scroll container (the overflow-y-auto div)
+    this.viewport = this.container.querySelector('.overflow-y-auto');
+    if (!this.viewport) return;
+
+    // Create spacer for full height scrollbar
+    this.spacer = document.createElement('div');
+    this.spacer.className = 'virtual-spacer';
+    this.spacer.style.height = `${this.totalRows * this.currentRowHeight}px`;
+    this.spacer.style.position = 'absolute';
+    this.spacer.style.top = '0';
+    this.spacer.style.left = '0';
+    this.spacer.style.right = '0';
+    this.spacer.style.pointerEvents = 'none';
+
+    // Create content container
+    this.content = document.createElement('div');
+    this.content.className = 'virtual-content';
+    this.content.style.position = 'relative';
+    this.content.style.zIndex = '1';
+
+    // Move existing rows into content container
+    const existingRows = this.viewport.querySelectorAll('.guide-row');
+    existingRows.forEach(row => this.content.appendChild(row));
+
+    // Set viewport to relative positioning
+    this.viewport.style.position = 'relative';
+
+    // Add spacer and content to viewport
+    this.viewport.appendChild(this.spacer);
+    this.viewport.insertBefore(this.content, this.spacer);
+
+    // Set initial rendered range based on SSR content
+    this.renderedRange = { start: 0, end: this.initialRows.length };
+  }
+
+  bindEvents() {
+    if (!this.viewport) return;
+
+    // Scroll handler with RAF for smooth updates
+    let ticking = false;
+    this.viewport.addEventListener('scroll', () => {
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          this.onScroll();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    }, { passive: true });
+
+    // Handle resize
+    const D = VIRTUAL_GUIDE_DEFAULTS;
+    let resizeTimer;
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        const wasMobile = this.isMobile;
+        this.isMobile = window.innerWidth < D.MOBILE_BREAKPOINT;
+        if (wasMobile !== this.isMobile) {
+          // Row height changed, update spacer
+          this.spacer.style.height = `${this.totalRows * this.currentRowHeight}px`;
+          this.updateVisibleRange();
+        }
+      }, D.RESIZE_DEBOUNCE_MS);
+    });
+  }
+
+  onScroll() {
+    const D = VIRTUAL_GUIDE_DEFAULTS;
+
+    // Clear any pending debounce
+    clearTimeout(this.fetchDebounce);
+    clearTimeout(this.renderDebounce);
+
+    const scrollTop = this.viewport.scrollTop;
+    const firstVisible = Math.floor(scrollTop / this.currentRowHeight);
+    const lastVisible = firstVisible + this.visibleCount;
+
+    // Track scroll direction
+    const scrollDelta = scrollTop - (this.lastScrollTop || 0);
+    this.lastScrollTop = scrollTop;
+    if (Math.abs(scrollDelta) > D.SCROLL_DIRECTION_THRESHOLD) {
+      this.scrollDirection = scrollDelta > 0 ? 'down' : 'up';
+    }
+
+    // Calculate desired range with buffer
+    const desiredStart = Math.max(0, firstVisible - this.bufferSize);
+    const desiredEnd = Math.min(this.totalRows, lastVisible + this.bufferSize);
+
+    // Check if we need to update rendered range
+    const needsRender = desiredStart < this.renderedRange.start ||
+                        desiredEnd > this.renderedRange.end;
+
+    if (needsRender) {
+      // Render immediately with whatever we have (placeholders for missing)
+      this.renderDebounce = setTimeout(() => {
+        this.renderedRange = { start: desiredStart, end: desiredEnd };
+        this.render();
+      }, D.RENDER_DEBOUNCE_MS);
+
+      // Debounce fetching - wait for scroll to settle before fetching
+      this.fetchDebounce = setTimeout(() => {
+        this.updateVisibleRange();
+      }, D.FETCH_DEBOUNCE_MS);
+    }
+  }
+
+  async updateVisibleRange() {
+    const scrollTop = this.viewport.scrollTop;
+    const firstVisible = Math.floor(scrollTop / this.currentRowHeight);
+    const lastVisible = firstVisible + this.visibleCount;
+
+    // Calculate ranges: visible, forward buffer, backward buffer
+    const visibleStart = Math.max(0, firstVisible);
+    const visibleEnd = Math.min(this.totalRows, lastVisible + 1);
+
+    const bufferStart = Math.max(0, firstVisible - this.bufferSize);
+    const bufferEnd = Math.min(this.totalRows, lastVisible + this.bufferSize);
+
+    // Priority fetch order based on scroll direction
+    const fetchOrder = [];
+
+    // 1. Always fetch visible rows first
+    const visibleMissing = this.findMissingRanges(visibleStart, visibleEnd);
+    if (visibleMissing.length > 0) {
+      fetchOrder.push({ ranges: visibleMissing, priority: 'visible' });
+    }
+
+    // 2. Fetch buffer in scroll direction
+    // 3. Fetch buffer in opposite direction
+    if (this.scrollDirection === 'down') {
+      const forwardMissing = this.findMissingRanges(visibleEnd, bufferEnd);
+      const backwardMissing = this.findMissingRanges(bufferStart, visibleStart);
+      if (forwardMissing.length > 0) fetchOrder.push({ ranges: forwardMissing, priority: 'forward' });
+      if (backwardMissing.length > 0) fetchOrder.push({ ranges: backwardMissing, priority: 'backward' });
+    } else {
+      const backwardMissing = this.findMissingRanges(bufferStart, visibleStart);
+      const forwardMissing = this.findMissingRanges(visibleEnd, bufferEnd);
+      if (backwardMissing.length > 0) fetchOrder.push({ ranges: backwardMissing, priority: 'backward' });
+      if (forwardMissing.length > 0) fetchOrder.push({ ranges: forwardMissing, priority: 'forward' });
+    }
+
+    // Fetch in priority order, re-rendering after each batch
+    for (const batch of fetchOrder) {
+      const success = await this.fetchMissingRanges(batch.ranges);
+      // Re-render after each batch so visible content appears first
+      this.renderedRange = { start: bufferStart, end: bufferEnd };
+      this.render();
+
+      if (!success) {
+        // A pending fetch exists or we just aborted one - don't fetch lower-priority buffers
+        // The recheck timeout will re-call updateVisibleRange with correct priorities
+        break;
+      }
+    }
+
+    // Always do a final render to ensure current position is shown
+    // This handles the case where fetchOrder is empty (all rows cached)
+    this.renderedRange = { start: bufferStart, end: bufferEnd };
+    this.render();
+  }
+
+  findMissingRanges(start, end) {
+    const ranges = [];
+    let rangeStart = null;
+
+    for (let i = start; i < end; i++) {
+      if (!this.cache.has(i)) {
+        if (rangeStart === null) rangeStart = i;
+      } else if (rangeStart !== null) {
+        ranges.push({ start: rangeStart, end: i });
+        rangeStart = null;
+      }
+    }
+
+    if (rangeStart !== null) {
+      ranges.push({ start: rangeStart, end });
+    }
+
+    return ranges;
+  }
+
+  /**
+   * Fetch missing rows for the given ranges.
+   * @returns {Promise<boolean>} true if fetch completed (or nothing to fetch),
+   *          false if a pending fetch blocked us or we aborted one
+   */
+  async fetchMissingRanges(ranges) {
+    // Early return if no ranges to fetch
+    if (!ranges || ranges.length === 0) {
+      return true;
+    }
+
+    // Merge into a single request for simplicity
+    const overallStart = Math.min(...ranges.map(r => r.start));
+    const overallEnd = Math.max(...ranges.map(r => r.end));
+
+    // If there's a pending fetch, check if it's for a relevant range
+    if (this.pendingFetch) {
+      if (this.pendingFetchRange) {
+        const p = this.pendingFetchRange;
+        const overlaps = !(overallEnd < p.start || overallStart > p.end);
+
+        if (overlaps) {
+          // Pending fetch will give us some useful data, let it finish
+          // The recheck timeout will catch any remaining gaps
+          this.needsRecheck = true;
+          return false;
+        }
+      }
+      // Non-overlapping or orphaned pending fetch - abort it
+      // Return false so caller doesn't continue to lower-priority fetches
+      this.pendingFetch.abort();
+      this.pendingFetch = null;
+      this.pendingFetchRange = null;
+
+      // CRITICAL: Schedule recheck ourselves since the aborted fetch's finally
+      // block won't do it (we already set pendingFetch = null)
+      clearTimeout(this.recheckTimeout);
+      this.recheckTimeout = setTimeout(() => {
+        this.updateVisibleRange();
+      }, 50);
+      return false;
+    }
+
+    const controller = new AbortController();
+    this.pendingFetch = controller;
+    this.pendingFetchRange = { start: overallStart, end: overallEnd };
+    // Clear needsRecheck since we're now fetching what we need
+    this.needsRecheck = false;
+
+    try {
+      // Don't pass cats - server uses saved user filter
+      // This keeps URLs short and avoids length limits
+      const params = new URLSearchParams({
+        start: overallStart,
+        count: overallEnd - overallStart,
+        offset: this.offset
+      });
+
+      const resp = await fetch(`/api/guide/rows?${params}`, {
+        signal: controller.signal
+      });
+
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+
+      const data = await resp.json();
+
+      // Cache the fetched rows
+      for (const row of data.rows) {
+        this.cache.set(row.index, row);
+      }
+
+      // Clear any failure tracking for this range
+      const rangeKey = `${overallStart}-${overallEnd}`;
+      this.failedRanges.delete(rangeKey);
+
+      // Evict old cache entries to prevent memory growth
+      this.pruneCache();
+    } catch (e) {
+      if (e.name !== 'AbortError') {
+        console.error('Failed to fetch guide rows:', e);
+
+        // Track failed range for retry
+        const rangeKey = `${overallStart}-${overallEnd}`;
+        const retryCount = (this.failedRanges.get(rangeKey) || 0) + 1;
+
+        if (retryCount < this.maxRetries) {
+          this.failedRanges.set(rangeKey, retryCount);
+          // Schedule retry after delay
+          setTimeout(() => {
+            this.failedRanges.delete(rangeKey);
+            this.updateVisibleRange();
+          }, 1000 * retryCount); // Exponential backoff: 1s, 2s, 3s
+        } else {
+          // Max retries reached - clear tracking
+          this.failedRanges.delete(rangeKey);
+          console.error(`Failed to fetch rows ${overallStart}-${overallEnd} after ${this.maxRetries} retries`);
+        }
+      }
+    } finally {
+      if (this.pendingFetch === controller) {
+        this.pendingFetch = null;
+        this.pendingFetchRange = null;
+
+        // Always recheck after fetch completes to catch any gaps
+        // Use a small delay to batch multiple rapid rechecks
+        clearTimeout(this.recheckTimeout);
+        this.recheckTimeout = setTimeout(() => {
+          this.updateVisibleRange();
+        }, 50);
+      }
+    }
+
+    return true;
+  }
+
+  render() {
+    if (!this.content) return;
+
+    const html = [];
+
+    for (let i = this.renderedRange.start; i < this.renderedRange.end; i++) {
+      const row = this.cache.get(i);
+      if (row) {
+        html.push(this.renderRow(row, i));
+      } else {
+        html.push(this.renderPlaceholder(i));
+      }
+    }
+
+    // Position content at the right scroll offset
+    this.content.style.transform = `translateY(${this.renderedRange.start * this.currentRowHeight}px)`;
+    this.content.innerHTML = html.join('');
+  }
+
+  /**
+   * Evict cached rows far from current view to prevent unbounded memory growth.
+   * Keeps rows within 2x buffer distance from current rendered range.
+   */
+  pruneCache() {
+    if (this.cache.size <= this.maxCacheSize) {
+      return;
+    }
+
+    const center = Math.floor((this.renderedRange.start + this.renderedRange.end) / 2);
+    const keepDistance = this.bufferSize * 2;
+
+    // Collect indices to remove (those far from current view)
+    const toRemove = [];
+    for (const index of this.cache.keys()) {
+      const distance = Math.abs(index - center);
+      if (distance > keepDistance) {
+        toRemove.push(index);
+      }
+    }
+
+    // Remove furthest first until under max size
+    toRemove.sort((a, b) => Math.abs(b - center) - Math.abs(a - center));
+    const removeCount = Math.min(toRemove.length, this.cache.size - this.maxCacheSize);
+    for (let i = 0; i < removeCount; i++) {
+      this.cache.delete(toRemove[i]);
+    }
+  }
+
+  renderPlaceholder(index) {
+    const height = this.currentRowHeight;
+    const isMobile = this.isMobile;
+
+    if (isMobile) {
+      return `
+        <div class="guide-row flex border-b border-gray-700 animate-pulse" data-row="${index}" style="height: ${height}px;">
+          <div class="compact-only w-32 flex-shrink-0 p-1 flex items-center bg-gray-800 sticky left-0 z-10 border-r border-gray-700">
+            <div class="h-3 bg-gray-600 rounded w-20"></div>
+          </div>
+          <div class="flex-1 relative ml-1">
+            <div class="absolute inset-0.5 bg-gray-700 rounded"></div>
+          </div>
+        </div>
+      `;
+    }
+
+    return `
+      <div class="guide-row flex border-b border-gray-700 animate-pulse" data-row="${index}" style="height: ${height}px;">
+        <div class="desktop-only w-36 lg:w-48 flex-shrink-0 p-1 flex items-center gap-2 bg-gray-800 sticky left-0 z-10 border-r border-gray-700">
+          <div class="w-10 h-10 bg-gray-600 rounded"></div>
+          <div class="h-4 bg-gray-600 rounded w-24"></div>
+        </div>
+        <div class="flex-1 relative ml-1">
+          <div class="absolute top-1 bottom-1 left-0 right-1/3 bg-gray-700 rounded"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  renderRow(row, index) {
+    const ch = row.channel;
+    const iconUrl = ch.icon ? this.logoUrlFilter(ch.icon) : '';
+    const height = this.currentRowHeight;
+
+    // Escape HTML in text content
+    const escapeHtml = (str) => {
+      if (!str) return '';
+      return str.replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+    };
+
+    // Desktop programs
+    let programsDesktop = '';
+    if (row.programs && row.programs.length > 0) {
+      programsDesktop = row.programs.map((prog, pIdx) => `
+        <a href="/play/live/${ch.stream_id}"
+           class="absolute top-1 bottom-1 bg-gray-700 hover:bg-gray-600 rounded px-2 py-1 overflow-hidden
+                  focusable border-2 border-transparent focus:border-blue-500 focus:bg-blue-900/50"
+           style="left: ${prog.left_pct}%; width: calc(${prog.width_pct}% - 4px);"
+           tabindex="0" data-nav="epg" data-row="${index}" data-col="${pIdx}"
+           title="${escapeHtml(prog.title)}&#10;${prog.start} - ${prog.end}&#10;${escapeHtml(prog.desc)}">
+          <div class="text-sm font-medium truncate">${escapeHtml(prog.title)}</div>
+          <div class="text-xs text-gray-400 truncate">${escapeHtml(prog.desc)}</div>
+        </a>
+      `).join('');
+    } else {
+      programsDesktop = `
+        <div class="absolute inset-1 flex items-center px-2 text-gray-500 text-sm">
+          No program info
+        </div>
+      `;
+    }
+
+    // Mobile programs
+    let programsMobile = '';
+    if (row.programs_mobile && row.programs_mobile.length > 0) {
+      programsMobile = row.programs_mobile.map((prog, pIdx) => `
+        <a href="/play/live/${ch.stream_id}"
+           class="absolute top-0.5 bottom-0.5 bg-gray-700 hover:bg-gray-600 rounded px-1 overflow-hidden
+                  focusable border border-gray-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 focus:ring-offset-gray-800"
+           style="left: ${prog.left_pct}%; width: calc(${prog.width_pct}% - 4px);"
+           tabindex="0" data-nav="epg" data-row="${index}" data-col="${pIdx}"
+           title="${escapeHtml(prog.title)}&#10;${prog.start} - ${prog.end}&#10;${escapeHtml(prog.desc)}">
+          <div class="text-[10px] font-medium truncate">${escapeHtml(prog.title)}</div>
+        </a>
+      `).join('');
+    } else {
+      programsMobile = `
+        <div class="absolute inset-0.5 flex items-center px-1 text-gray-500 text-[10px]">
+          No info
+        </div>
+      `;
+    }
+
+    return `
+      <div class="guide-row flex border-b border-gray-700 hover:bg-gray-750" data-row="${index}">
+        <!-- Mobile Channel Info -->
+        <div class="compact-only w-32 flex-shrink-0 p-1 items-center bg-gray-800 sticky left-0 z-10 border-r border-gray-700">
+          <a href="/play/live/${ch.stream_id}"
+             class="text-xs line-clamp-2 hover:text-blue-400 focus:text-blue-400 focus:outline focus:outline-2 focus:outline-blue-500 focusable"
+             tabindex="0" data-nav="epg" data-row="${index}" data-col="-1"
+             title="${escapeHtml(ch.name)}">
+            ${escapeHtml(ch.name)}
+          </a>
+        </div>
+
+        <!-- Desktop Channel Info -->
+        <div class="desktop-only w-36 lg:w-48 flex-shrink-0 p-1 items-center gap-1 bg-gray-800 sticky left-0 z-10 border-r border-gray-700">
+          ${iconUrl ? `<img src="${iconUrl}" alt="" class="w-10 h-10 object-contain" onerror="this.style.display='none'">` : ''}
+          <a href="/play/live/${ch.stream_id}"
+             class="text-sm line-clamp-3 hover:text-blue-400 focus:text-blue-400 focus:outline focus:outline-2 focus:outline-blue-500 focusable"
+             tabindex="0" data-nav="epg" data-row="${index}" data-col="-1"
+             title="${escapeHtml(ch.name)}">
+            ${escapeHtml(ch.name)}
+          </a>
+        </div>
+
+        <!-- Mobile Programs (2-hour window) -->
+        <div class="compact-only-block flex-1 relative h-10 ml-1">
+          ${programsMobile}
+        </div>
+
+        <!-- Desktop Programs -->
+        <div class="desktop-only-block flex-1 relative h-16 ml-1">
+          ${programsDesktop}
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * Clean up resources when the virtual guide is no longer needed.
+   * Call this before removing/reinitializing to prevent memory leaks.
+   */
+  destroy() {
+    // Clear all timers
+    clearTimeout(this.fetchDebounce);
+    clearTimeout(this.renderDebounce);
+    clearTimeout(this.scrollDebounce);
+    clearTimeout(this.recheckTimeout);
+
+    // Abort any pending fetch
+    if (this.pendingFetch) {
+      this.pendingFetch.abort();
+      this.pendingFetch = null;
+      this.pendingFetchRange = null;
+    }
+
+    // Clear caches
+    this.cache.clear();
+    this.failedRanges.clear();
+
+    // Clear DOM references
+    if (this.content) {
+      this.content.innerHTML = '';
+    }
+    this.viewport = null;
+    this.content = null;
+    this.spacer = null;
+    this.container = null;
+
+    // Note: Event listeners on window (resize) are not removed
+    // as they use anonymous functions. For full cleanup, would need
+    // to store references to bound handlers in constructor.
+  }
+}
+
+// Export for use
+window.VirtualGuide = VirtualGuide;

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -50,8 +50,20 @@
   <div class="desktop-only flex-wrap items-center justify-between gap-2 mb-4">
     <div class="min-w-0 flex items-center gap-2">
       <h2 class="text-xl sm:text-3xl font-bold">Live TV</h2>
-      {% if selected_cats %}
-      <a href="/settings#filters" class="text-sm text-gray-400 hover:text-blue-400">{{ selected_cats|length }} categories &mdash; {{ channel_count }} channels</a>
+      {% if saved_filter or selected_cats %}
+      <!-- Category filter dropdown -->
+      <select id="category-filter" class="bg-gray-700 text-sm rounded px-2 py-1 border border-gray-600 focus:border-blue-500 focus:outline-none">
+        <option value="">All categories</option>
+        {% for cat in categories %}
+        {% if cat.category_id|string in (saved_filter or selected_cats) %}
+        <option value="{{ cat.category_id }}" {% if cats_param == cat.category_id|string %}selected{% endif %}>
+          {{ cat.category_name }}
+        </option>
+        {% endif %}
+        {% endfor %}
+      </select>
+      <span class="text-xs text-gray-500">({{ total_count | default(channel_count) }} ch)</span>
+      <a href="/settings#filters" class="text-xs text-gray-500 hover:text-blue-400">[edit]</a>
       {% endif %}
     </div>
     <div class="flex gap-1">
@@ -85,6 +97,18 @@
   <div class="compact-only mobile-header items-center justify-between gap-1 p-2 bg-gray-900 border-b border-gray-700 rounded-t-lg">
     <div class="flex items-center gap-1">
       <span class="text-sm font-bold">Live TV</span>
+      {% if saved_filter or selected_cats %}
+      <select id="category-filter-mobile" class="bg-gray-700 text-[10px] rounded px-1 py-0.5 border border-gray-600 max-w-[120px]">
+        <option value="">All</option>
+        {% for cat in categories %}
+        {% if cat.category_id|string in (saved_filter or selected_cats) %}
+        <option value="{{ cat.category_id }}" {% if cats_param == cat.category_id|string %}selected{% endif %}>
+          {{ cat.category_name }}
+        </option>
+        {% endif %}
+        {% endfor %}
+      </select>
+      {% endif %}
     </div>
     <div class="flex gap-1">
       <a href="/guide?offset={{ offset - 2 }}{% if cats_param %}&cats={{ cats_param }}{% endif %}"
@@ -208,18 +232,64 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="/static/js/virtual-guide.js"></script>
 <script>
-// Handle category filter: sync to server when URL has cats
+// Virtual scroll configuration
+const GUIDE_CONFIG = {
+  totalRows: {{ total_count | default(0) }},
+  offset: {{ offset }},
+  cats: {{ cats_param | tojson }},
+  initialRows: {{ grid_data | tojson | safe }},
+  // Logo URL proxy (matches _logo_url_filter in Python)
+  logoUrlFilter: function(url) {
+    if (!url || url.startsWith('/') || url.startsWith('data:')) {
+      return url;
+    }
+    try {
+      const parsed = new URL(url);
+      const source = parsed.hostname.split(':')[0] || 'external';
+      return '/api/logo?source=' + encodeURIComponent(source) + '&url=' + encodeURIComponent(url);
+    } catch (e) {
+      return url;
+    }
+  }
+};
+
+// Handle category filter: sync to server when URL has cats (but not temp filters)
 (function() {
   const urlCats = '{{ cats_param }}';
-  if (urlCats) {
-    // Have cats in URL - sync to server
+  const urlParams = new URLSearchParams(window.location.search);
+  const isTempFilter = urlParams.get('filter') === '1';
+
+  // Only sync to saved filter if it's not a temporary dropdown filter
+  if (urlCats && !isTempFilter) {
     fetch('/settings/guide-filter', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({cats: urlCats.split(',')})
     });
   }
+})();
+
+// Category dropdown filter
+(function() {
+  function handleCategoryChange(e) {
+    const catId = e.target.value;
+    const offset = {{ offset }};
+    if (catId) {
+      // Filter to single category - add filter=1 to indicate temp filter
+      window.location.href = `/guide?offset=${offset}&cats=${catId}&filter=1`;
+    } else {
+      // "All" selected - use saved filter (no cats param)
+      window.location.href = `/guide?offset=${offset}`;
+    }
+  }
+
+  const dropdown = document.getElementById('category-filter');
+  const dropdownMobile = document.getElementById('category-filter-mobile');
+
+  if (dropdown) dropdown.addEventListener('change', handleCategoryChange);
+  if (dropdownMobile) dropdownMobile.addEventListener('change', handleCategoryChange);
 })();
 
 // Auto-refresh when EPG finishes loading
@@ -247,16 +317,35 @@
 })();
 {% endif %}
 
+// Initialize virtual scrolling if we have more than initial batch
+(function() {
+  if (GUIDE_CONFIG.totalRows > GUIDE_CONFIG.initialRows.length && GUIDE_CONFIG.totalRows > 0) {
+    const container = document.querySelector('.guide-container');
+    if (container) {
+      window.virtualGuide = new VirtualGuide({
+        container: container,
+        totalRows: GUIDE_CONFIG.totalRows,
+        initialRows: GUIDE_CONFIG.initialRows,
+        offset: GUIDE_CONFIG.offset,
+        cats: GUIDE_CONFIG.cats,
+        rowHeight: 64,  // 4rem desktop
+        rowHeightMobile: 40,  // 2.5rem mobile
+        bufferSize: 50,
+        logoUrlFilter: GUIDE_CONFIG.logoUrlFilter
+      });
+    }
+  }
+})();
+
 // EPG-specific keyboard navigation
 (function() {
   function isVisible(el) {
     return el.offsetParent !== null;
   }
 
+  // Use total count for keyboard navigation range
   const maxRow = () => {
-    const cells = Array.from(document.querySelectorAll('[data-nav="epg"]')).filter(isVisible);
-    const rows = cells.map(el => parseInt(el.dataset.row) || 0);
-    return Math.max(...rows, 0);
+    return Math.max(0, GUIDE_CONFIG.totalRows - 1);
   };
 
   function getVisiblePrograms(row) {
@@ -297,6 +386,28 @@
   }
 
   function focusCell(row, col) {
+    // If virtual scrolling is active, ensure row is in view first
+    if (window.virtualGuide) {
+      const vg = window.virtualGuide;
+      const rowHeight = vg.currentRowHeight;
+      const viewport = vg.viewport;
+
+      // Check if row is outside rendered range
+      if (row < vg.renderedRange.start || row >= vg.renderedRange.end) {
+        // Scroll to bring row into view, then focus after render
+        const targetScroll = row * rowHeight - (viewport.clientHeight / 2) + (rowHeight / 2);
+        viewport.scrollTop = Math.max(0, targetScroll);
+
+        // Wait for render and then focus
+        setTimeout(() => doFocus(row, col), 100);
+        return;
+      }
+    }
+
+    doFocus(row, col);
+  }
+
+  function doFocus(row, col) {
     let cell;
     if (col === -1) {
       const candidates = document.querySelectorAll(`[data-nav="epg"][data-row="${row}"][data-col="-1"]`);
@@ -382,11 +493,15 @@
   });
 
   // Save/restore scroll position (persists across reloads and navigation)
+  // Note: VirtualGuide handles scroll restore for virtual scrolling mode
   const scrollKey = 'guide_scroll';
   const gridContainer = document.querySelector('.overflow-y-auto');
   if (gridContainer) {
-    const saved = sessionStorage.getItem(scrollKey);
-    if (saved) gridContainer.scrollTop = parseInt(saved);
+    // Only restore if not using virtual scrolling (VirtualGuide handles it)
+    if (!window.virtualGuide) {
+      const saved = sessionStorage.getItem(scrollKey);
+      if (saved) gridContainer.scrollTop = parseInt(saved);
+    }
     // Save on scroll (debounced)
     let scrollTimer;
     gridContainer.addEventListener('scroll', () => {


### PR DESCRIPTION
Closes #30

## Summary

This PR implements virtual scrolling for the TV guide to handle large channel lists (20k+ channels) without choking the browser. Before this change, loading the full EPG grid would trigger those "page unresponsive - do you want to wait or cancel?" dialogs and make the browser sluggish.

**What it does:**
- Only renders ~130 rows at a time (visible + buffer above/below)
- Fetches additional rows via API as user scrolls
- Adds priority-based loading (visible rows first, then buffers in scroll direction)
- Includes a category dropdown filter for quick single-category filtering
- Server-side rendering of initial batch for fast first paint

**Key changes:**
- New `/api/guide/rows` endpoint for paginated row fetching
- New `static/js/virtual-guide.js` - VirtualGuide class with caching, retry logic, cache eviction
- Updated `templates/guide.html` with virtual scroll container and category filter dropdown

I know this is sort of two features in one (lazy loading + category filtering), so if you'd prefer to implement this differently or cherry-pick parts, no hard feelings at all! Just wanted to share what worked for my setup.

## Test plan
- [x] Load guide with large playlist - should show initial rows immediately
- [x] Scroll quickly through guide - rows load with skeleton placeholders
- [x] Rapid scrolling in multiple directions - always recovers and loads
- [x] Category dropdown filters to single category
- [x] "All Categories" returns to full list