### PR TITLE
Add Picture-in-Picture button to player

### DIFF
--- a/static/js/player.js
+++ b/static/js/player.js
@@ -758,6 +758,7 @@
           if (cfg.isVod) document.getElementById('jump-btn')?.click();
           break;
         case 'n': document.getElementById('autonext-btn')?.click(); break;
+        case 'p': document.getElementById('pip-btn')?.click(); break;
         case 'h':
           const container = document.getElementById('player-container');
           if (container.classList.contains('controls-visible')) {
@@ -941,6 +942,25 @@
       updateCcButton();
       saveSettings({ ccEnabled });
     });
+
+    // PiP button
+    const pipBtn = document.getElementById('pip-btn');
+    if (pipBtn && document.pictureInPictureEnabled) {
+      pipBtn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        try {
+          if (document.pictureInPictureElement) {
+            await document.exitPictureInPicture();
+          } else {
+            await video.requestPictureInPicture();
+          }
+        } catch (err) {
+          console.error('[PiP] Error:', err);
+        }
+      });
+    } else if (pipBtn) {
+      pipBtn.style.display = 'none';
+    }
 
     // Settings menu toggle
     document.getElementById('settings-btn')?.addEventListener('click', () => {

--- a/templates/player.html
+++ b/templates/player.html
@@ -139,6 +139,9 @@
           <button id="toggle-cc" class="ctrl-btn" title="Captions (c)">
             <svg viewBox="0 0 24 24"><path d="M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-8 7H9.5v-.5h-2v3h2V13H11v1c0 .55-.45 1-1 1H7c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1zm7 0h-1.5v-.5h-2v3h2V13H18v1c0 .55-.45 1-1 1h-3c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1z"/></svg>
           </button>
+          <button id="pip-btn" class="ctrl-btn" title="Picture-in-Picture (p)">
+            <svg viewBox="0 0 24 24"><path d="M19 7h-8v6h8V7zm2-4H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14z"/></svg>
+          </button>
 
           <!-- Settings dropdown -->
           <div class="relative">


### PR DESCRIPTION
## Summary

Adds a Picture-in-Picture (PiP) button to the player controls, allowing users to pop the video out into a floating window.

- PiP button added next to captions button
- Keyboard shortcut 'p' toggles PiP
- Button auto-hides if browser doesn't support PiP
- Uses native browser PiP API

**Note:** This uses native browser PiP which works within the player page. A persistent mini-player/sidebar that stays visible while navigating the EPG would require larger architectural changes (SPA-style navigation or iframe approach) since page navigation destroys the video element.

## Test plan
- [x] Click PiP button - video pops into floating window
- [x] Press 'p' key - toggles PiP
- [x] Click PiP button again or close PiP window - returns to normal
- [x] Works while video is playing