### PR TITLE
Fix Chromecast button not showing behind reverse proxy

### DIFF
--- a/main.py
+++ b/main.py
@@ -1519,11 +1519,11 @@ async def player_page(
     server_settings = load_server_settings()
     user_settings = load_user_settings(username)
     transcode_mode = server_settings.get("transcode_mode", "auto")
+    is_https = (
+        request.url.scheme == "https" or request.headers.get("x-forwarded-proto") == "https"
+    )
     if transcode_mode == "auto":
         needs_transcode = info.is_m3u or ext in ("mkv", "mp4", "avi", "wmv", "flv")
-        is_https = (
-            request.url.scheme == "https" or request.headers.get("x-forwarded-proto") == "https"
-        )
         mixed_content = is_https and info.url.startswith("http://")
         if needs_transcode or mixed_content:
             transcode_mode = "always"
@@ -1565,6 +1565,7 @@ async def player_page(
             "deinterlace_fallback": info.deinterlace_fallback,
             "source_id": info.source_id,
             "content_access": _get_content_access(username),
+            "is_https": is_https,
         },
     )
 

--- a/templates/player.html
+++ b/templates/player.html
@@ -159,7 +159,7 @@
             </div>
           </div>
 
-          {% if request.url.scheme == 'https' %}
+          {% if is_https %}
           <button id="cast-btn" class="ctrl-btn" title="Cast" disabled>
             <svg viewBox="0 0 24 24"><path d="M21 3H3c-1.1 0-2 .9-2 2v3h2V5h18v14h-7v2h7c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM1 18v3h3c0-1.66-1.34-3-3-3zm0-4v2c2.76 0 5 2.24 5 5h2c0-3.87-3.13-7-7-7zm0-4v2c4.97 0 9 4.03 9 9h2c0-6.08-4.93-11-11-11z"/></svg>
           </button>
@@ -192,7 +192,7 @@ window.PLAYER_CONFIG = {
   ccStyle: {{ cc_style | tojson }},
   ccLang: {{ cc_lang | tojson }},
   castHost: {{ cast_host | tojson }},
-  isHttps: {{ (request.url.scheme == 'https') | tojson }},
+  isHttps: {{ is_https | tojson }},
   deinterlaceFallback: {{ deinterlace_fallback | tojson }},
   sourceId: {{ source_id | tojson }}
 };


### PR DESCRIPTION
The Cast button checks for HTTPS but only looked at `request.url.scheme`, missing the `X-Forwarded-Proto` header that reverse proxies set.

The `is_https` check was already computed correctly in `player_page()` but wasn't being passed to the template. Now it is.

Note: I don't run behind HTTPS locally so couldn't test this directly, but the logic follows the same pattern used elsewhere in the codebase.

Fixes #41