### PR TITLE
Fix Live TV filter not saving for large playlists (#50)

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,6 +109,9 @@ _login_attempts: dict[str, list[float]] = {}
 _LOGIN_WINDOW = 300  # 5 minutes
 _LOGIN_MAX_ATTEMPTS = 10
 
+# Category filter limits
+_MAX_FILTER_CATEGORIES = 10000
+
 
 # =============================================================================
 # App Setup
@@ -2150,7 +2153,7 @@ async def settings_guide_filter(
     username = user.get("sub", "")
     data = await request.json()
     cats = data.get("cats", [])
-    if not isinstance(cats, list) or len(cats) > 500:
+    if not isinstance(cats, list) or len(cats) > _MAX_FILTER_CATEGORIES:
         raise HTTPException(400, "Invalid filter list")
     user_settings = load_user_settings(username)
     user_settings["guide_filter"] = cats
@@ -2166,7 +2169,7 @@ async def settings_vod_filter(
     username = user.get("sub", "")
     data = await request.json()
     cats = data.get("cats", [])
-    if not isinstance(cats, list) or len(cats) > 500:
+    if not isinstance(cats, list) or len(cats) > _MAX_FILTER_CATEGORIES:
         raise HTTPException(400, "Invalid filter list")
     user_settings = load_user_settings(username)
     user_settings["vod_filter"] = cats
@@ -2182,7 +2185,7 @@ async def settings_series_filter(
     username = user.get("sub", "")
     data = await request.json()
     cats = data.get("cats", [])
-    if not isinstance(cats, list) or len(cats) > 500:
+    if not isinstance(cats, list) or len(cats) > _MAX_FILTER_CATEGORIES:
         raise HTTPException(400, "Invalid filter list")
     user_settings = load_user_settings(username)
     user_settings["series_filter"] = cats

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -934,24 +934,24 @@
 {% block scripts %}
 <script>
 window.SETTINGS_CONFIG = {
-  currentUser: {{ current_user | tojson }},
-  selectedCats: {{ selected_cats | tojson }},
-  selectedVodCats: {{ selected_vod_cats | tojson }},
-  selectedSeriesCats: {{ selected_series_cats | tojson }},
+  currentUser: {{ current_user | tojson | safe }},
+  selectedCats: {{ selected_cats | tojson | safe }},
+  selectedVodCats: {{ selected_vod_cats | tojson | safe }},
+  selectedSeriesCats: {{ selected_series_cats | tojson | safe }},
   catNames: {
-    {% for cat in live_categories %}{{ cat.category_id | tojson }}: {{ cat.category_name | tojson }}{% if not loop.last %},{% endif %}
+    {% for cat in live_categories %}{{ cat.category_id | tojson | safe }}: {{ cat.category_name | tojson | safe }}{% if not loop.last %},{% endif %}
     {% endfor %}
   },
   vodCatNames: {
-    {% for cat in vod_categories %}{{ cat.category_id | tojson }}: {{ cat.category_name | tojson }}{% if not loop.last %},{% endif %}
+    {% for cat in vod_categories %}{{ cat.category_id | tojson | safe }}: {{ cat.category_name | tojson | safe }}{% if not loop.last %},{% endif %}
     {% endfor %}
   },
   seriesCatNames: {
-    {% for cat in series_categories %}{{ cat.category_id | tojson }}: {{ cat.category_name | tojson }}{% if not loop.last %},{% endif %}
+    {% for cat in series_categories %}{{ cat.category_id | tojson | safe }}: {{ cat.category_name | tojson | safe }}{% if not loop.last %},{% endif %}
     {% endfor %}
   },
-  ccStyle: {{ cc_style | tojson }},
-  ccLang: {{ cc_lang | tojson }}
+  ccStyle: {{ cc_style | tojson | safe }},
+  ccLang: {{ cc_lang | tojson | safe }}
 };
 </script>
 <script src="/static/js/settings.js"></script>


### PR DESCRIPTION
## Summary

Fixes #50 - Live TV filter always filters all channels

Two issues were identified that could cause filter settings to not persist:

### 1. Category limit too restrictive (500 → 10,000)

The `/settings/guide-filter` endpoint rejected requests with more than 500 categories. For providers with large channel lists (like the 60k channels reported), this limit was easily exceeded, causing saves to silently fail.

- Added `_MAX_FILTER_CATEGORIES = 10000` constant
- Applied to all three filter endpoints (guide, vod, series)

### 2. HTML encoding mismatch with `&` in category names

When category names contained `&` (e.g., "Animals & Nature"):
- HTML `data-id` attributes were escaped: `&` → `&amp;` (then decoded by browser)
- JavaScript config used `tojson` without `| safe`, so `&` → `&amp;` (not decoded in script tags)
- This caused ID comparison to fail on page reload

Fixed by adding `| safe` after all `tojson` filters in the settings template script block.

## Test Plan

**Note:** I don't have a provider with this specific issue, so I haven't been able to directly reproduce and test against it. The app works fine on my end, but verification from affected users would be helpful.

- [ ] User with >500 Live TV categories tests "Allow All" and confirms it persists after page reload
- [ ] User with `&` in category names tests that those categories can be saved and persist
- [ ] Verify Movies and Series filters still work as expected