### PR TITLE
Fix EPG fetch failing with connection reset by peer

### DIFF
--- a/epg.py
+++ b/epg.py
@@ -364,12 +364,21 @@ def fetch_epg(
     cache_dir: Path,
     timeout: int = 120,
     source_id: str = "",
+    user_agent: str | None = None,
 ) -> int:
     """Fetch and parse XMLTV EPG data directly into sqlite.
 
-    Returns number of programs inserted.
+    Args:
+        epg_url: URL of the XMLTV EPG feed
+        cache_dir: Directory for debug files if parsing fails
+        timeout: Request timeout in seconds
+        source_id: Source identifier for multi-source support
+        user_agent: User-Agent header to send. If None, uses default.
+
+    Returns:
+        Number of programs inserted.
     """
-    with safe_urlopen(epg_url, timeout=timeout) as resp:
+    with safe_urlopen(epg_url, timeout=timeout, user_agent=user_agent) as resp:
         content = resp.read()
         with contextlib.suppress(Exception):
             content = gzip.decompress(content)

--- a/main.py
+++ b/main.py
@@ -509,12 +509,13 @@ async def index(request: Request, _user: Annotated[dict, Depends(require_auth)])
 
 def _fetch_all_epg(epg_urls: list[tuple[str, int, str]]) -> int:
     """Fetch EPG from all URLs into sqlite (in parallel). Returns total program count."""
+    user_agent = ffmpeg_command.get_user_agent()
 
     def fetch_one(url_timeout_source: tuple[str, int, str]) -> tuple[str, int]:
         url, timeout, source_id = url_timeout_source
         try:
             log.info("Fetching EPG (timeout=%ds): %s", timeout, url[:80])
-            count = fetch_epg(url, CACHE_DIR, timeout=timeout, source_id=source_id)
+            count = fetch_epg(url, CACHE_DIR, timeout=timeout, source_id=source_id, user_agent=user_agent)
             log.info("EPG done: %d programs from %s", count, url[:50])
             return url, count
         except Exception as e:

--- a/util.py
+++ b/util.py
@@ -27,10 +27,14 @@ class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
+_USER_AGENT = "VLC/3.0.20 LibVLC/3.0.20"
+
+
 def safe_urlopen(url: str, timeout: int = 30) -> Any:
     """Open URL with safe redirect handling."""
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme not in ("http", "https"):
         raise urllib.error.URLError(f"Unsafe URL scheme: {parsed.scheme}")
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
     opener = urllib.request.build_opener(_SafeRedirectHandler())
-    return opener.open(url, timeout=timeout)
+    return opener.open(req, timeout=timeout)

--- a/util.py
+++ b/util.py
@@ -27,14 +27,22 @@ class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
-_USER_AGENT = "VLC/3.0.20 LibVLC/3.0.20"
+_DEFAULT_USER_AGENT = "VLC/3.0.20 LibVLC/3.0.20"
 
 
-def safe_urlopen(url: str, timeout: int = 30) -> Any:
-    """Open URL with safe redirect handling."""
+def safe_urlopen(url: str, timeout: int = 30, user_agent: str | None = None) -> Any:
+    """Open URL with safe redirect handling.
+
+    Args:
+        url: URL to open
+        timeout: Request timeout in seconds
+        user_agent: User-Agent header to send. If None, uses a default VLC User-Agent
+            to avoid being blocked by providers that reject Python's default.
+    """
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme not in ("http", "https"):
         raise urllib.error.URLError(f"Unsafe URL scheme: {parsed.scheme}")
-    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    ua = user_agent if user_agent else _DEFAULT_USER_AGENT
+    req = urllib.request.Request(url, headers={"User-Agent": ua})
     opener = urllib.request.build_opener(_SafeRedirectHandler())
     return opener.open(req, timeout=timeout)


### PR DESCRIPTION
## Summary

- Add VLC User-Agent header to HTTP requests in `safe_urlopen()`
- Many IPTV providers block Python's default User-Agent (`Python-urllib/3.x`), causing "Connection reset by peer" errors when fetching EPG data

## Test plan

- [x] Verified EPG fetch works with providers that previously failed
- [x] Tested with curl using the same User-Agent header

🤖 Generated with [Claude Code](https://claude.ai/code)