### PR TITLE
Fix broken covers in favorites

### DIFF
--- a/templates/movie_detail.html
+++ b/templates/movie_detail.html
@@ -6,7 +6,7 @@
   {% if movie %}
   <div class="flex gap-2 sm:gap-6 mb-6">
     {% if movie.cover_big or movie.stream_icon %}
-    <img src="{{ (movie.cover_big or movie.stream_icon) | logo_url }}" alt="" class="w-24 sm:w-36 lg:w-48 h-auto max-h-72 object-cover rounded-lg flex-shrink-0">
+    <img id="cover" src="{{ (movie.cover_big or movie.stream_icon) | logo_url }}" alt="" class="w-24 sm:w-36 lg:w-48 h-auto max-h-72 object-cover rounded-lg flex-shrink-0">
     {% endif %}
     <div class="min-w-0 flex-1">
       <div class="flex flex-wrap items-center justify-between gap-2 mb-2">
@@ -63,7 +63,7 @@
 let favorites = {{ favorites | tojson }};
 const MOVIE_ID = '{{ movie.stream_id if movie else "" }}';
 const MOVIE_NAME = '{{ movie.name | e if movie else "" }}';
-const MOVIE_COVER = '{{ (movie.stream_icon or "") | logo_url | e if movie else "" }}';
+const MOVIE_COVER = document.getElementById('cover')?.getAttribute('src') ?? "";
 const MOVIE_EXT = '{{ movie.container_extension or "mkv" if movie else "mkv" }}';
 
 function saveFavorites() {

--- a/templates/series_detail.html
+++ b/templates/series_detail.html
@@ -6,7 +6,7 @@
   {% if series.info %}
   <div class="flex gap-2 sm:gap-6 mb-6">
     {% if series.info.cover %}
-    <img src="{{ series.info.cover | logo_url }}" alt="" class="w-24 sm:w-36 lg:w-48 h-auto max-h-72 object-cover rounded-lg flex-shrink-0">
+    <img id="cover" src="{{ series.info.cover | logo_url }}" alt="" class="w-24 sm:w-36 lg:w-48 h-auto max-h-72 object-cover rounded-lg flex-shrink-0">
     {% endif %}
     <div class="min-w-0 flex-1">
       <div class="flex flex-wrap items-center justify-between gap-2 mb-2">
@@ -74,7 +74,7 @@
 let favorites = {{ favorites | tojson }};
 const SERIES_ID = '{{ series_id }}';
 const SERIES_NAME = '{{ series.info.name | e if series.info else "" }}';
-const SERIES_COVER = '{{ (series.info.cover or "") | logo_url | e if series.info else "" }}';
+const SERIES_COVER = document.getElementById('cover')?.getAttribute('src') ?? "";
 
 function saveFavorites() {
   fetch('/api/user-prefs', {


### PR DESCRIPTION
This fixes a bug which breaks the cover URI when adding VOD/Series to favorites from within the detail pages.