### PR TITLE
Send configured User-Agent on channel/VOD/series fetches

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -514,6 +514,24 @@ def save_server_settings(settings: dict[str, Any]) -> None:
     SERVER_SETTINGS_FILE.write_text(json.dumps(settings, indent=2))
 
 
+USER_AGENT_PRESETS = {
+    "vlc": "VLC/3.0.20 LibVLC/3.0.20",
+    "chrome": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "tivimate": "TiviMate/4.7.0",
+}
+
+
+def get_user_agent() -> str | None:
+    """Get the configured User-Agent, or None for the caller's own default."""
+    settings = load_server_settings()
+    preset = settings.get("user_agent_preset", "default")
+    if preset == "default":
+        return None
+    if preset == "custom":
+        return settings.get("user_agent_custom") or None
+    return USER_AGENT_PRESETS.get(preset)
+
+
 def _validate_username(username: str) -> None:
     """Validate username to prevent path traversal and length attacks."""
     if (

--- a/ffmpeg_command.py
+++ b/ffmpeg_command.py
@@ -17,7 +17,7 @@ import threading
 import time
 
 # Import VAAPI auto-detection results (avoid circular import by importing constants only)
-from cache import AVAILABLE_ENCODERS, VAAPI_DEVICE
+from cache import AVAILABLE_ENCODERS, VAAPI_DEVICE, get_user_agent
 
 
 log = logging.getLogger(__name__)
@@ -52,13 +52,6 @@ TEXT_SUBTITLE_CODECS = {
     "mov_text",
     "webvtt",
     "srt",
-}
-
-# User-Agent presets
-_USER_AGENT_PRESETS = {
-    "vlc": "VLC/3.0.20 LibVLC/3.0.20",
-    "chrome": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-    "tivimate": "TiviMate/4.7.0",
 }
 
 # NVDEC capabilities by minimum compute capability
@@ -352,22 +345,6 @@ def _has_libplacebo_filter() -> bool:
     except Exception as e:
         log.debug("libplacebo probe failed: %s", e)
     return _has_libplacebo
-
-
-# ===========================================================================
-# User-Agent
-# ===========================================================================
-
-
-def get_user_agent() -> str | None:
-    """Get user-agent string from settings, or None to use FFmpeg default."""
-    settings = _load_settings()
-    preset = settings.get("user_agent_preset", "default")
-    if preset == "default":
-        return None
-    if preset == "custom":
-        return settings.get("user_agent_custom") or None
-    return _USER_AGENT_PRESETS.get(preset)
 
 
 # ===========================================================================

--- a/ffmpeg_command_test.py
+++ b/ffmpeg_command_test.py
@@ -575,19 +575,19 @@ class TestUserAgent:
 
     def test_default_user_agent(self):
         """Test default preset returns None."""
-        with patch("ffmpeg_command._load_settings", return_value={"user_agent_preset": "default"}):
+        with patch("cache.load_server_settings", return_value={"user_agent_preset": "default"}):
             assert get_user_agent() is None
 
     def test_vlc_user_agent(self):
         """Test VLC preset."""
-        with patch("ffmpeg_command._load_settings", return_value={"user_agent_preset": "vlc"}):
+        with patch("cache.load_server_settings", return_value={"user_agent_preset": "vlc"}):
             ua = get_user_agent()
             assert ua is not None
             assert "VLC" in ua
 
     def test_chrome_user_agent(self):
         """Test Chrome preset."""
-        with patch("ffmpeg_command._load_settings", return_value={"user_agent_preset": "chrome"}):
+        with patch("cache.load_server_settings", return_value={"user_agent_preset": "chrome"}):
             ua = get_user_agent()
             assert ua is not None
             assert "Chrome" in ua
@@ -595,7 +595,7 @@ class TestUserAgent:
     def test_custom_user_agent(self):
         """Test custom user agent."""
         with patch(
-            "ffmpeg_command._load_settings",
+            "cache.load_server_settings",
             return_value={"user_agent_preset": "custom", "user_agent_custom": "MyAgent/1.0"},
         ):
             assert get_user_agent() == "MyAgent/1.0"
@@ -603,7 +603,7 @@ class TestUserAgent:
     def test_custom_empty_returns_none(self):
         """Test empty custom user agent returns None."""
         with patch(
-            "ffmpeg_command._load_settings",
+            "cache.load_server_settings",
             return_value={"user_agent_preset": "custom", "user_agent_custom": ""},
         ):
             assert get_user_agent() is None

--- a/m3u.py
+++ b/m3u.py
@@ -16,6 +16,7 @@ from cache import (
     get_cache,
     get_cache_lock,
     get_sources,
+    get_user_agent,
     load_file_cache,
     save_file_cache,
     update_source_epg_url,
@@ -33,6 +34,13 @@ _fetch_locks: dict[str, threading.Lock] = {
     "series": threading.Lock(),
     "epg": threading.Lock(),
 }
+
+
+def _make_client(source: Any) -> XtreamClient:
+    """Build an Xtream client using the configured User-Agent."""
+    return XtreamClient(
+        source.url, source.username, source.password, user_agent=get_user_agent()
+    )
 
 
 def parse_m3u(content: str, source_id: str) -> tuple[list[dict], list[dict], str]:
@@ -101,7 +109,7 @@ def parse_m3u(content: str, source_id: str) -> tuple[list[dict], list[dict], str
 
 def fetch_m3u(url: str, source_id: str, timeout: int = 30) -> tuple[list[dict], list[dict], str]:
     """Fetch and parse M3U from URL, return (categories, streams, epg_url)."""
-    with safe_urlopen(url, timeout=timeout) as resp:
+    with safe_urlopen(url, timeout=timeout, user_agent=get_user_agent()) as resp:
         content = resp.read().decode("utf-8")
     return parse_m3u(content, source_id)
 
@@ -115,7 +123,7 @@ def _fetch_all_live_data() -> tuple[list[dict], list[dict], list[tuple[str, int,
     for source in get_sources():
         try:
             if source.type == "xtream":
-                client = XtreamClient(source.url, source.username, source.password)
+                client = _make_client(source)
                 cats = client.get_live_categories()
                 streams = client.get_live_streams()
                 for c in cats:
@@ -155,7 +163,7 @@ def fetch_source_live_data(source: Any) -> tuple[list[dict], list[dict], str | N
     epg_url: str | None = None
 
     if source.type == "xtream":
-        client = XtreamClient(source.url, source.username, source.password)
+        client = _make_client(source)
         cats = client.get_live_categories()
         streams = client.get_live_streams()
         for c in cats:
@@ -186,7 +194,7 @@ def fetch_source_vod_data(source: Any) -> tuple[list[dict], list[dict]]:
     """Fetch VOD data for a single Xtream source."""
     if source.type != "xtream":
         return [], []
-    client = XtreamClient(source.url, source.username, source.password)
+    client = _make_client(source)
     cats = client.get_vod_categories()
     streams = client.get_vod_streams()
     # Tag with source_id for playback
@@ -257,7 +265,7 @@ def _fetch_vod_data() -> tuple[list[dict], list[dict]]:
         if source.type != "xtream":
             continue
         try:
-            client = XtreamClient(source.url, source.username, source.password)
+            client = _make_client(source)
             cats = client.get_vod_categories()
             streams = client.get_vod_streams()
             # Tag with source_id for playback and access control
@@ -323,7 +331,7 @@ def _fetch_series_data() -> tuple[list[dict], list[dict]]:
         if source.type != "xtream":
             continue
         try:
-            client = XtreamClient(source.url, source.username, source.password)
+            client = _make_client(source)
             cats = client.get_series_categories()
             series = client.get_series()
             # Tag with source_id for playback and access control
@@ -385,7 +393,7 @@ def get_first_xtream_client() -> XtreamClient | None:
     """Get the first available Xtream client (for VOD/series)."""
     for source in get_sources():
         if source.type == "xtream":
-            return XtreamClient(source.url, source.username, source.password)
+            return _make_client(source)
     return None
 
 
@@ -393,7 +401,7 @@ def get_xtream_client_by_source(source_id: str) -> XtreamClient | None:
     """Get Xtream client for a specific source ID."""
     for source in get_sources():
         if source.id == source_id and source.type == "xtream":
-            return XtreamClient(source.url, source.username, source.password)
+            return _make_client(source)
     return None
 
 
@@ -401,7 +409,7 @@ def get_first_xtream_source_and_client() -> tuple[str, XtreamClient] | tuple[Non
     """Get the first available Xtream source ID and client."""
     for source in get_sources():
         if source.type == "xtream":
-            return source.id, XtreamClient(source.url, source.username, source.password)
+            return source.id, _make_client(source)
     return None, None
 
 

--- a/m3u_test.py
+++ b/m3u_test.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import json
 
 import pytest
+
+import cache
 
 
 @pytest.fixture
@@ -120,6 +126,27 @@ class TestFetchLocks:
     def test_get_refresh_in_progress(self, m3u_module):
         rip = m3u_module.get_refresh_in_progress()
         assert isinstance(rip, set)
+
+
+class TestMakeClientUserAgent:
+    """m3u fetches must use the configured User-Agent (issue #57)."""
+
+    def test_make_client_uses_persisted_user_agent(self, m3u_module):
+        source = SimpleNamespace(url="http://example.com", username="u", password="p")
+        cache.SERVER_SETTINGS_FILE.write_text(
+            json.dumps({"user_agent_preset": "custom", "user_agent_custom": "MyAgent/9.9"})
+        )
+        assert m3u_module._make_client(source).user_agent == "MyAgent/9.9"
+
+    def test_fetch_m3u_sends_user_agent(self, m3u_module):
+        cache.SERVER_SETTINGS_FILE.write_text(json.dumps({"user_agent_preset": "vlc"}))
+        resp = MagicMock()
+        resp.read.return_value = b"#EXTM3U\n"
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch.object(m3u_module, "safe_urlopen", return_value=resp) as mock_open:
+            m3u_module.fetch_m3u("http://example.com/list.m3u", "src1")
+        assert mock_open.call_args.kwargs["user_agent"] == cache.USER_AGENT_PRESETS["vlc"]
 
 
 if __name__ == "__main__":

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -612,7 +612,7 @@
   <!-- User-Agent -->
   <div id="user-agent" class="mb-8 p-4 bg-gray-800 rounded">
     <h3 class="text-xl font-semibold mb-4">User-Agent</h3>
-    <p class="text-sm text-gray-400 mb-4">HTTP User-Agent header sent when fetching streams. Only affects transcoding; passthrough uses the client's native user-agent.</p>
+    <p class="text-sm text-gray-400 mb-4">HTTP User-Agent header sent when fetching streams, channel lists, VOD/series metadata, and EPG. Some providers reject requests with an unexpected User-Agent (HTTP 403). Stream passthrough uses the client's native user-agent.</p>
     <div class="space-y-4" id="user-agent-settings">
       <div class="space-y-2">
         <label class="flex items-center gap-3 cursor-pointer text-sm">

--- a/xtream.py
+++ b/xtream.py
@@ -21,6 +21,8 @@ class XtreamClient:
     base_url: str
     username: str
     password: str
+    # Some providers reject API requests with an unexpected User-Agent (HTTP 403).
+    user_agent: str | None = None
 
     def __post_init__(self) -> None:
         # Normalize URL: strip trailing slashes
@@ -36,7 +38,7 @@ class XtreamClient:
         return f"{self.base_url}/player_api.php?{params}"
 
     def _fetch(self, url: str, timeout: int = 30) -> str:
-        with safe_urlopen(url, timeout=timeout) as resp:
+        with safe_urlopen(url, timeout=timeout, user_agent=self.user_agent) as resp:
             return resp.read().decode("utf-8")
 
     def _api(self, action: str | None = None, timeout: int = 30, **params: Any) -> Any:

--- a/xtream_test.py
+++ b/xtream_test.py
@@ -294,6 +294,36 @@ class TestXtreamClientApi:
         assert "limit=5" in url
 
 
+class TestXtreamClientUserAgent:
+    """The configured User-Agent must be sent on API calls (issue #57).
+
+    Some providers return HTTP 403 for channel list / VOD / series requests
+    that omit the same User-Agent used for stream playback.
+    """
+
+    @pytest.fixture
+    def mock_urlopen(self):
+        with patch("xtream.safe_urlopen") as mock:
+            resp = MagicMock()
+            resp.read.return_value = b"[]"
+            resp.__enter__ = MagicMock(return_value=resp)
+            resp.__exit__ = MagicMock(return_value=False)
+            mock.return_value = resp
+            yield mock
+
+    def test_defaults_to_none(self):
+        assert XtreamClient("http://example.com", "user", "pass").user_agent is None
+
+    def test_user_agent_forwarded_to_urlopen(self, mock_urlopen):
+        client = XtreamClient("http://example.com", "user", "pass", user_agent="TiviMate/4.7.0")
+        client.get_live_streams()
+        assert mock_urlopen.call_args.kwargs["user_agent"] == "TiviMate/4.7.0"
+
+    def test_none_user_agent_forwarded_so_default_applies(self, mock_urlopen):
+        XtreamClient("http://example.com", "user", "pass").get_live_streams()
+        assert mock_urlopen.call_args.kwargs["user_agent"] is None
+
+
 if __name__ == "__main__":
     from testing import run_tests
 


### PR DESCRIPTION
Fixes #57.

## Problem

#58 fixed #57 for **EPG only**. The reporter hit 403s on live, VOD, *and* EPG, but the Xtream API client and M3U playlist fetches still called `safe_urlopen()` without a `user_agent`, so they silently fell back to the hardcoded `VLC/3.0.20` default in `util.py`.

Net effect: **the User-Agent setting in Settings was ignored** for every channel list, VOD, and series refresh. The reporter's 403s cleared only because the VLC fallback happened to satisfy his provider — anyone whose provider requires a different UA (including the default `tivimate` preset) still gets 403s.

## Changes

- `XtreamClient` takes a `user_agent` and forwards it on every API call, so live/VOD/series/detail/short-EPG all inherit it from one place.
- `m3u.py` builds every client through a new `_make_client()` (replacing 8 duplicated constructions), which applies the configured UA. `fetch_m3u()` sends it too.
- `get_user_agent()` moves from `ffmpeg_command.py` to `cache.py`, beside the settings schema it reads. This keeps data fetching from importing the transcoding module, and removes any dependency on `ffmpeg_command.init()` having run first.
- Updated the Settings description, which still claimed the setting "only affects transcoding" — the fix @tjrivian asked for in the last comment on #57.

Deliberately **not** changed: `_fetch_logo()`. Logo URLs often point at third-party CDNs rather than the provider, so forwarding a provider-specific UA there risks breaking logos that work today.

Also unchanged: `get_user_agent()` returns `None` for the `default` preset meaning "use FFmpeg's own UA", while `safe_urlopen(user_agent=None)` means "use the VLC fallback". That conflation predates this PR (it came in with the EPG fix) and is worth its own discussion.

## Testing

- `ruff check .` clean, `basedpyright` 0 errors
- **386 passed** (from 381)
- New tests cover UA forwarding through `XtreamClient`, plus an end-to-end check that writes a real settings file and asserts the value reaches the client with no mocking — the gap that let the original bug through.
