### PR TITLE
Stop daily application image rebuilds

### DIFF
--- a/.github/workflows/ai-upscale.yml
+++ b/.github/workflows/ai-upscale.yml
@@ -1,18 +1,14 @@
 name: AI Upscale Image
 
 on:
-  workflow_dispatch:  # Manual trigger
+  # Run manually when an FFmpeg base-image update should be published immediately.
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
       - "Dockerfile.ai_upscale"
       - "entrypoint-ai_upscale.sh"
       - ".github/workflows/ai-upscale.yml"
-  workflow_run:
-    # Also trigger after ffmpeg-base completes to pick up new ffmpeg image
-    workflows: ["FFmpeg Base Image"]
-    types: [completed]
-    branches: [main]
 
 env:
   REGISTRY: ghcr.io
@@ -21,8 +17,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Skip if triggered by failed ffmpeg workflow
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       packages: write
@@ -48,8 +42,6 @@ jobs:
           df -h
 
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 on:
-  workflow_dispatch:  # Manual trigger
+  # Run manually when an FFmpeg base-image update should be published immediately.
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -15,11 +16,6 @@ on:
       - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
-  workflow_run:
-    # Trigger after ffmpeg-base completes to pick up new ffmpeg image
-    workflows: ["FFmpeg Base Image"]
-    types: [completed]
-    branches: [main]
 
 env:
   REGISTRY: ghcr.io
@@ -29,13 +25,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Skip if triggered by failed ffmpeg workflow
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          # For workflow_run, checkout the commit that triggered ffmpeg build
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -66,8 +57,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ffmpeg-base.yml
+++ b/.github/workflows/ffmpeg-base.yml
@@ -3,6 +3,7 @@ name: FFmpeg Base Image
 on:
   schedule:
     # Build daily at 3 AM UTC
+    # Application images are rebuilt separately on code changes or manual dispatch.
     - cron: "0 3 * * *"
   push:
     branches: [main]

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ docker compose up -d
 
 Open http://localhost:8000. To update: `docker compose pull && docker compose up -d`
 
+The `latest` image is published on tagged releases, on application changes
+merged to `main`, and when a maintainer triggers a rebuild manually. Scheduled
+FFmpeg base-image builds do not republish application images, so
+`docker compose pull` will not report an update every day.
+
 #### Optional: Nonfree (proprietary) FFMPEG optimized for Nvidia or AMD and/or Intel GPU
 
 We provide a custom built ffmpeg with Nvidia, AMD, and Intel _proprietary


### PR DESCRIPTION
Fixes #62.

## Root cause

The scheduled `FFmpeg Base Image` workflow runs every day with `no-cache: true` and a new `BUILD_DATE`, producing a new base-image digest. Both application workflows listened for that completion through `workflow_run`, then rebuilt and pushed new `netv:latest` and `netv-ai-upscale:latest` digests even when no neTV application code had changed.

Container managers therefore correctly reported a new neTV update every day, despite there being no corresponding commit or release.

## Changes

- Stop triggering the main neTV image build after every scheduled FFmpeg base build.
- Apply the same fix to the AI-upscale image workflow.
- Remove the conditions and explicit checkout refs used only by `workflow_run` events.
- Keep daily FFmpeg base-image builds unchanged.
- Keep manual application rebuilds available when an important FFmpeg update should be propagated immediately.
- Document when application images are published.

## Result

Application images are now published for relevant source changes, tagged releases, or explicit manual rebuilds. Scheduled FFmpeg base-image builds no longer create daily application-image update prompts.

## Review

Rubber-duck review found no blockers. It identified the equivalent daily rebuild path in the AI-upscale workflow, which is included in this fix.

## Validation

- All changed workflow files parse as valid YAML.
- `git diff --check` passes.
