### PR TITLE
feat: add standalone native-player gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,15 +55,17 @@ RUN if python3 -m pip install --help 2>&1 | grep -q -- '--break-system-packages'
     fi
 
 # Runtime config
-EXPOSE 8000
+EXPOSE 8000 8100
 
 # Environment variables (see README for details)
 ENV NETV_PORT=8000
+ENV NETV_GATEWAY_PORT=8100
 ENV NETV_HTTPS=""
 ENV LOG_LEVEL=INFO
 
-# Create non-root user (entrypoint handles permissions and group membership)
-RUN useradd -m netv
+# Match the gateway image so both services can safely share the cache volume.
+RUN groupadd --gid 10001 netv && \
+    useradd --uid 10001 --gid 10001 --create-home netv
 
 # Copy entrypoint and set permissions with validation
 COPY entrypoint.sh /app/
@@ -73,6 +75,6 @@ RUN chmod +x /app/entrypoint.sh && \
 # Healthcheck with improved error handling
 # Note: start-period allows time for application startup
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD python3 -c "import urllib.request; r=urllib.request.urlopen('http://localhost:8000/', timeout=5); exit(0 if r.status==200 else 1)" 2>/dev/null || exit 1
+    CMD python3 -c "import os, urllib.request; gateway=os.environ.get('NETV_MODE') == 'gateway'; port=os.environ.get('NETV_GATEWAY_PORT', '8100') if gateway else os.environ.get('NETV_PORT', '8000'); path='/healthz' if gateway else '/'; r=urllib.request.urlopen(f'http://localhost:{port}{path}', timeout=5); exit(0 if r.status==200 else 1)" 2>/dev/null || exit 1
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile.ai_upscale
+++ b/Dockerfile.ai_upscale
@@ -89,7 +89,8 @@ ENV LOG_LEVEL=INFO
 ENV SR_ENGINE_DIR=/models
 
 # Create non-root user
-RUN useradd -m netv
+RUN groupadd --gid 10001 netv && \
+    useradd --uid 10001 --gid 10001 --create-home netv
 
 # Copy entrypoint and set permissions with validation
 COPY entrypoint-ai_upscale.sh /app/entrypoint.sh

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -1,0 +1,33 @@
+# Architecture-neutral image for the native-player gateway.
+FROM python:3.11-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY *.py ./
+
+RUN python3 -m pip install --no-cache-dir . && \
+    groupadd --gid 10001 netv && \
+    useradd --uid 10001 --gid 10001 --create-home netv && \
+    mkdir -p /app/cache && \
+    chown -R netv:netv /app/cache
+
+COPY entrypoint.sh /app/
+RUN chmod +x /app/entrypoint.sh
+
+ENV NETV_MODE=gateway
+ENV NETV_GATEWAY_PORT=8100
+ENV LOG_LEVEL=INFO
+
+EXPOSE 8100
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD python3 -c "import urllib.request; r=urllib.request.urlopen('http://localhost:8100/healthz', timeout=5); exit(0 if r.status==200 else 1)" 2>/dev/null || exit 1
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ through their IPTV providers.
 ## Features
 
 - **Live TV** with EPG grid guide
+- **Native player gateway** - Use the configured live channels from Xtream-compatible players
 - **Movies & Series** with metadata, seasons, episodes
 - **AI Upscale** - Real-time 4x upscaling via TensorRT (720p → 4K @ 85fps)
 - **Chromecast** support (HTTPS required)
@@ -150,6 +151,17 @@ services:
     devices:
       - /dev/dri:/dev/dri  # for hardware transcoding (remove if no GPU)
     restart: unless-stopped
+
+  netv-gateway:
+    image: ghcr.io/jvdillon/netv:latest
+    ports:
+      - "8100:8100"
+    environment:
+      - NETV_MODE=gateway
+      - NETV_GATEWAY_PORT=8100
+    volumes:
+      - ./cache:/app/cache
+    restart: unless-stopped
 ```
 
 Then run:
@@ -159,6 +171,50 @@ docker compose up -d
 ```
 
 Open http://localhost:8000. To update: `docker compose pull && docker compose up -d`
+
+#### Native player gateway
+
+The gateway exposes the live sources configured in the neTV web UI through a
+separate Xtream-compatible endpoint. Configure sources and users at
+`http://localhost:8000`, then enter the following details in a native IPTV
+player:
+
+```text
+Server:   http://<netv-host>:8100
+Username: <your neTV username>
+Password: <your neTV password>
+```
+
+The gateway currently supports live categories, live streams, MPEG-TS M3U
+playlists, short EPG lookups, user-filtered XMLTV, and live passthrough
+playback. VOD, series, and standalone upscaling will be added in later phases.
+Remote provider credentials and playback URLs are not returned to the player.
+
+The gateway currently does not enforce the per-user `max_streams_per_source`
+setting or coordinate per-source connection counts with the web process. Use a
+provider account with sufficient connections and avoid aggressive multi-channel
+preview features in native players.
+
+Use a dedicated non-admin neTV account for native players because Xtream
+clients include their local credentials in stream URLs.
+
+When running from a source checkout, the gateway has an architecture-neutral
+image and can be started independently:
+
+```bash
+docker compose up -d --build netv-gateway
+```
+
+If neTV is behind a reverse proxy or the address seen by the container is not
+reachable by the player, set `NETV_GATEWAY_PUBLIC_URL` to the externally
+reachable gateway URL, such as `http://192.168.1.20:8100`.
+Use only a scheme, host, and optional port; path prefixes are not supported.
+Forwarded client addresses are trusted only from localhost by default. If a
+reverse proxy runs elsewhere, set `NETV_GATEWAY_TRUSTED_PROXIES` to its IP
+address or a comma-separated list of proxy IP addresses.
+
+For restricted users, the gateway hides uncategorized streams because they
+cannot be proven to belong to an allowed category.
 
 The `latest` image is published on tagged releases, on application changes
 merged to `main`, and when a maintainer triggers a rebuild manually. Scheduled
@@ -298,6 +354,7 @@ Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/):
 git clone https://github.com/jvdillon/netv.git
 cd netv
 uv run ./main.py --port 8000  # --https
+uv run ./gateway.py --port 8100
 ```
 
 Or with pip:

--- a/auth.py
+++ b/auth.py
@@ -11,6 +11,8 @@ import pathlib
 import secrets
 import time
 
+from util import atomic_write_json
+
 
 APP_DIR = pathlib.Path(__file__).parent
 # Use old "cache" if it exists (backwards compat), otherwise ".cache"
@@ -34,7 +36,7 @@ def _get_secret_key() -> str:
         settings = json.loads(settings_file.read_text())
     if "secret_key" not in settings:
         settings["secret_key"] = secrets.token_hex(32)
-        settings_file.write_text(json.dumps(settings, indent=2))
+        atomic_write_json(settings_file, settings)
     return settings["secret_key"]
 
 
@@ -88,7 +90,7 @@ def create_user(username: str, password: str, admin: bool = False) -> None:
         admin = True
     users[username] = {"password": _hash_password(password), "admin": admin}
     settings["users"] = users
-    settings_file.write_text(json.dumps(settings, indent=2))
+    atomic_write_json(settings_file, settings)
     # Create user directory for per-user settings
     user_dir = USERS_DIR / username
     user_dir.mkdir(parents=True, exist_ok=True)
@@ -113,7 +115,7 @@ def delete_user(username: str) -> bool:
     del users[username]
     _ensure_one_admin(users)
     settings["users"] = users
-    settings_file.write_text(json.dumps(settings, indent=2))
+    atomic_write_json(settings_file, settings)
     return True
 
 
@@ -137,7 +139,7 @@ def change_password(username: str, new_password: str) -> bool:
         return False
     users[username]["password"] = _hash_password(new_password)
     settings["users"] = users
-    settings_file.write_text(json.dumps(settings, indent=2))
+    atomic_write_json(settings_file, settings)
     return True
 
 
@@ -160,7 +162,7 @@ def set_admin(username: str, admin: bool) -> bool:
     users[username]["admin"] = admin
     _ensure_one_admin(users)
     settings["users"] = users
-    settings_file.write_text(json.dumps(settings, indent=2))
+    atomic_write_json(settings_file, settings)
     return True
 
 
@@ -206,7 +208,7 @@ def set_user_limits(
     if unavailable_groups is not None:
         users[username]["unavailable_groups"] = unavailable_groups
     settings["users"] = users
-    settings_file.write_text(json.dumps(settings, indent=2))
+    atomic_write_json(settings_file, settings)
     return True
 
 

--- a/cache.py
+++ b/cache.py
@@ -15,6 +15,8 @@ import threading
 import time
 import urllib.parse
 
+from util import atomic_write_json
+
 
 log = logging.getLogger(__name__)
 
@@ -511,7 +513,7 @@ def load_server_settings() -> dict[str, Any]:
 
 def save_server_settings(settings: dict[str, Any]) -> None:
     """Save server-wide settings."""
-    SERVER_SETTINGS_FILE.write_text(json.dumps(settings, indent=2))
+    atomic_write_json(SERVER_SETTINGS_FILE, settings)
 
 
 USER_AGENT_PRESETS = {
@@ -616,5 +618,6 @@ def update_source_epg_url(source_id: str, epg_url: str) -> None:
         if s["id"] == source_id and not s.get("epg_url"):
             s["epg_url"] = epg_url
             save_server_settings(settings)
-            log.info("Saved EPG URL for source %s: %s", source_id, epg_url)
+            host = urllib.parse.urlparse(epg_url).hostname or "unknown host"
+            log.info("Saved EPG URL for source %s (%s)", source_id, host)
             break

--- a/cache_test.py
+++ b/cache_test.py
@@ -210,6 +210,22 @@ class TestUpdateSourceEpgUrl:
         loaded = cache_module.load_server_settings()
         assert "epg_url" not in loaded["sources"][0]
 
+    def test_update_source_epg_url_does_not_log_credentials(self, cache_module, caplog):
+        caplog.set_level("INFO", logger=cache_module.log.name)
+        settings = {
+            "sources": [{"id": "s1", "name": "S1", "type": "xtream", "url": "http://x"}]
+        }
+        cache_module.save_server_settings(settings)
+
+        cache_module.update_source_epg_url(
+            "s1",
+            "https://provider.example/xmltv.php?username=private-user&password=private-secret",
+        )
+
+        assert "private-user" not in caplog.text
+        assert "private-secret" not in caplog.text
+        assert "provider.example" in caplog.text
+
 
 class TestEncoderDetection:
     """Tests for encoder detection functions."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,36 @@ services:
     devices:
       - /dev/dri:/dev/dri
 
+  # Xtream-compatible endpoint for native IPTV players.
+  netv-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile.gateway
+    image: netv-gateway
+    container_name: netv-gateway
+    ports:
+      - "${NETV_GATEWAY_PORT:-8100}:8100"
+    environment:
+      - NETV_MODE=gateway
+      - NETV_GATEWAY_PORT=8100
+      - NETV_GATEWAY_PUBLIC_URL=${NETV_GATEWAY_PUBLIC_URL:-}
+      - NETV_GATEWAY_TRUSTED_PROXIES=${NETV_GATEWAY_TRUSTED_PROXIES:-127.0.0.1}
+      - LOG_LEVEL=INFO
+    volumes:
+      - ./cache:/app/cache
+      - /etc/localtime:/etc/localtime:ro
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD
+        - python3
+        - -c
+        - "import urllib.request; r=urllib.request.urlopen('http://localhost:8100/healthz', timeout=5); exit(0 if r.status==200 else 1)"
+      interval: 30s
+      timeout: 10s
+      start_period: 10s
+      retries: 3
+
   # NVIDIA GPU: docker compose --profile nvidia up -d
   netv-nvidia:
     extends:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,5 +61,8 @@ if [ -e /dev/dri/renderD128 ]; then
     fi
 fi
 
-# Drop to netv user and run the app
+# Drop to netv user and run the selected app
+if [ "${NETV_MODE:-web}" = "gateway" ]; then
+    exec gosu netv python3 gateway.py --port "${NETV_GATEWAY_PORT:-8100}"
+fi
 exec gosu netv python3 main.py --port "${NETV_PORT:-8000}" ${NETV_HTTPS:+--https}

--- a/gateway.py
+++ b/gateway.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Xtream-compatible native-player gateway for neTV."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import argparse
+import asyncio
+import contextlib
+import hashlib
+import logging
+import os
+import threading
+import time
+import urllib.error
+import urllib.parse
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from gateway_catalog import CatalogSnapshot, GatewayCatalog, GatewayStream
+from gateway_epg import EpgUnavailableError, build_filtered_xmltv
+from m3u import get_xtream_client_by_source
+from util import safe_urlopen
+
+import auth
+import cache
+
+
+log = logging.getLogger(__name__)
+app = FastAPI(title="neTV Native Player Gateway", docs_url=None, redoc_url=None)
+catalog = GatewayCatalog()
+_PASSTHROUGH_ACTIONS = {
+    "get_vod_categories",
+    "get_vod_streams",
+    "get_series_categories",
+    "get_series",
+}
+_AUTH_CACHE_SECONDS = 30
+_LOGIN_WINDOW_SECONDS = 300
+_MAX_LOGIN_FAILURES = 10
+_MAX_GLOBAL_LOGIN_FAILURES = 100
+_MAX_AUTH_CACHE_ENTRIES = 1024
+_MAX_FAILURE_CLIENTS = 1024
+
+
+class GatewayAuthenticator:
+    """Rate-limit login failures and cache successful password checks briefly."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._failures: dict[str, list[float]] = {}
+        self._global_failures: list[float] = []
+        self._success_cache: dict[str, float] = {}
+
+    @staticmethod
+    def _fingerprint(username: str, password: str) -> str:
+        return hashlib.sha256(f"{username}\0{password}".encode()).hexdigest()
+
+    async def verify(self, request: Request, username: str, password: str) -> bool:
+        client_ip = request.client.host if request.client else "unknown"
+        fingerprint = self._fingerprint(username, password)
+        now = time.monotonic()
+        with self._lock:
+            expires_at = self._success_cache.get(fingerprint, 0)
+            if expires_at > now:
+                return True
+            self._success_cache.pop(fingerprint, None)
+
+            cutoff = now - _LOGIN_WINDOW_SECONDS
+            self._global_failures = [
+                timestamp
+                for timestamp in self._global_failures
+                if timestamp > cutoff
+            ]
+            self._failures = {
+                key: [timestamp for timestamp in timestamps if timestamp > cutoff]
+                for key, timestamps in self._failures.items()
+                if any(timestamp > cutoff for timestamp in timestamps)
+            }
+            failures = self._failures.get(client_ip, [])
+            if (
+                len(failures) >= _MAX_LOGIN_FAILURES
+                or len(self._global_failures) >= _MAX_GLOBAL_LOGIN_FAILURES
+            ):
+                raise HTTPException(429, "Too many login attempts, try again later")
+
+        valid = await asyncio.to_thread(auth.verify_password, username, password)
+        now = time.monotonic()
+        with self._lock:
+            if valid:
+                self._failures.pop(client_ip, None)
+                if len(self._success_cache) >= _MAX_AUTH_CACHE_ENTRIES:
+                    self._success_cache = {
+                        key: expiry
+                        for key, expiry in self._success_cache.items()
+                        if expiry > now
+                    }
+                    if len(self._success_cache) >= _MAX_AUTH_CACHE_ENTRIES:
+                        oldest = min(
+                            self._success_cache.items(),
+                            key=lambda item: item[1],
+                        )[0]
+                        del self._success_cache[oldest]
+                self._success_cache[fingerprint] = now + _AUTH_CACHE_SECONDS
+            else:
+                if (
+                    client_ip not in self._failures
+                    and len(self._failures) >= _MAX_FAILURE_CLIENTS
+                ):
+                    oldest_client = min(
+                        self._failures,
+                        key=lambda key: self._failures[key][-1],
+                    )
+                    del self._failures[oldest_client]
+                self._failures.setdefault(client_ip, []).append(now)
+                self._global_failures.append(now)
+        return valid
+
+
+authenticator = GatewayAuthenticator()
+
+
+def _public_base_url(request: Request) -> str:
+    configured = os.environ.get("NETV_GATEWAY_PUBLIC_URL", "").strip()
+    return (configured or str(request.base_url)).rstrip("/")
+
+
+def _server_info(request: Request, username: str, password: str) -> dict[str, Any]:
+    url = urllib.parse.urlparse(_public_base_url(request))
+    now = int(time.time())
+    return {
+        "user_info": {
+            "username": username,
+            "password": password,
+            "message": "neTV native-player gateway",
+            "auth": 1,
+            "status": "Active",
+            "exp_date": None,
+            "is_trial": "0",
+            "active_cons": "0",
+            "created_at": "0",
+            "max_connections": "1",
+            "allowed_output_formats": ["ts"],
+        },
+        "server_info": {
+            "url": url.hostname or "localhost",
+            "port": str(url.port or (443 if url.scheme == "https" else 80)),
+            "https_port": str(url.port or 443) if url.scheme == "https" else "",
+            "server_protocol": url.scheme,
+            "rtmp_port": "0",
+            "timezone": "UTC",
+            "timestamp_now": now,
+            "time_now": time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(now)),
+        },
+    }
+
+
+def _allowed_category_ids(username: str, snapshot: CatalogSnapshot) -> set[str]:
+    unavailable = set(auth.get_user_limits(username).get("unavailable_groups", []))
+    category_restricted = any(value.startswith("cat:") for value in unavailable)
+    allowed: set[str] = set()
+    for category in snapshot.categories:
+        public_id = str(category["category_id"])
+        access_id = snapshot.category_access_ids.get(public_id)
+        if access_id is None:
+            if not category_restricted:
+                allowed.add(public_id)
+        elif f"cat:{access_id}" not in unavailable:
+            allowed.add(public_id)
+    return allowed
+
+
+def _visible_streams(
+    username: str,
+    snapshot: CatalogSnapshot,
+    category_id: str | None = None,
+) -> list[GatewayStream]:
+    unavailable = set(auth.get_user_limits(username).get("unavailable_groups", []))
+    category_restricted = any(value.startswith("cat:") for value in unavailable)
+    streams = [
+        stream
+        for stream in snapshot.streams
+        if (
+            (stream.access_group_ids or not category_restricted)
+            and not any(
+                f"cat:{category}" in unavailable for category in stream.access_group_ids
+            )
+        )
+    ]
+    if category_id is not None:
+        streams = [
+            stream for stream in streams if category_id in stream.public["category_ids"]
+        ]
+    return streams
+
+
+async def _get_catalog() -> CatalogSnapshot:
+    return await asyncio.to_thread(catalog.get)
+
+
+def _auth_failure() -> JSONResponse:
+    return JSONResponse(
+        {
+            "user_info": {
+                "auth": 0,
+                "status": "Disabled",
+                "message": "Invalid username or password",
+            }
+        }
+    )
+
+
+@app.get("/healthz")
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/player_api.php")
+async def player_api(
+    request: Request,
+    username: str = Query(""),
+    password: str = Query(""),
+    action: str | None = None,
+    category_id: str | None = None,
+    stream_id: int | None = None,
+    limit: int = 10,
+) -> Any:
+    authenticated = await authenticator.verify(request, username, password)
+    log.info(
+        "Xtream request authenticated=%s action=%s",
+        authenticated,
+        action or "server_info",
+    )
+    if not authenticated:
+        return _auth_failure()
+    if action is None:
+        return _server_info(request, username, password)
+
+    snapshot = await _get_catalog()
+    allowed_categories = _allowed_category_ids(username, snapshot)
+    if action == "get_live_categories":
+        return [
+            category
+            for category in snapshot.categories
+            if str(category["category_id"]) in allowed_categories
+        ]
+    if action == "get_live_streams":
+        return [
+            stream.public
+            for stream in _visible_streams(username, snapshot, category_id)
+        ]
+    if action == "get_short_epg":
+        if stream_id is None:
+            raise HTTPException(400, "stream_id is required")
+        stream = snapshot.streams_by_id.get(stream_id)
+        if stream is None or stream not in _visible_streams(username, snapshot):
+            raise HTTPException(404, "Stream not found")
+        client = get_xtream_client_by_source(stream.source_id)
+        if client is None:
+            return {"epg_listings": []}
+        try:
+            return await asyncio.to_thread(
+                client.get_short_epg,
+                int(stream.upstream_id),
+                max(1, min(limit, 100)),
+            )
+        except (OSError, TypeError, ValueError, urllib.error.URLError) as exc:
+            log.warning("Gateway EPG lookup failed (%s)", type(exc).__name__)
+            raise HTTPException(502, "Unable to load upstream EPG data") from exc
+    if action in _PASSTHROUGH_ACTIONS:
+        return []
+    raise HTTPException(400, f"Unsupported action: {action}")
+
+
+def _m3u_value(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").replace('"', "'")
+
+
+@app.get("/get.php")
+async def playlist(
+    request: Request,
+    username: str = Query(""),
+    password: str = Query(""),
+    output: str = "ts",
+    type: str = "m3u_plus",
+) -> Response:
+    if not await authenticator.verify(request, username, password):
+        return Response("Invalid username or password\n", status_code=401, media_type="text/plain")
+    if type not in ("m3u", "m3u_plus"):
+        raise HTTPException(400, "Unsupported playlist type")
+    if output not in ("", "ts", "mpegts"):
+        raise HTTPException(400, "Only MPEG-TS output is currently supported")
+    base_url = _public_base_url(request)
+    encoded_user = urllib.parse.quote(username, safe="")
+    encoded_password = urllib.parse.quote(password, safe="")
+    epg_query = urllib.parse.urlencode({"username": username, "password": password})
+    lines = [f'#EXTM3U url-tvg="{base_url}/xmltv.php?{epg_query}"']
+    snapshot = await _get_catalog()
+    categories = {
+        str(category["category_id"]): str(category["category_name"])
+        for category in snapshot.categories
+    }
+    for stream in _visible_streams(username, snapshot):
+        info = stream.public
+        group = categories.get(str(info["category_id"]), "Uncategorized")
+        lines.append(
+            '#EXTINF:-1 tvg-id="{epg}" tvg-name="{name}" tvg-logo="{logo}" '
+            'group-title="{group}",{name}'.format(
+                epg=_m3u_value(info["epg_channel_id"]),
+                name=_m3u_value(info["name"]),
+                logo=_m3u_value(info["stream_icon"]),
+                group=_m3u_value(group),
+            )
+        )
+        lines.append(
+            f"{base_url}/live/{encoded_user}/{encoded_password}/{stream.local_id}.ts"
+        )
+    return Response("\n".join(lines) + "\n", media_type="audio/x-mpegurl")
+
+
+def _resolve_upstream(stream: GatewayStream, extension: str) -> str:
+    if stream.source_type == "m3u":
+        if not stream.direct_url:
+            raise HTTPException(502, "Source stream URL is missing")
+        return stream.direct_url
+    client = get_xtream_client_by_source(stream.source_id)
+    if client is None:
+        raise HTTPException(404, "Source is no longer configured")
+    return client.build_stream_url("live", int(stream.upstream_id), extension)
+
+
+def _iter_upstream(upstream: Any) -> Iterator[bytes]:
+    with contextlib.closing(upstream):
+        while chunk := upstream.read(64 * 1024):
+            yield chunk
+
+
+async def _proxy_url(url: str) -> StreamingResponse:
+    try:
+        upstream = await asyncio.to_thread(
+            safe_urlopen,
+            url,
+            30,
+            cache.get_user_agent(),
+        )
+    except (OSError, urllib.error.URLError) as exc:
+        log.warning("Gateway upstream connection failed (%s)", type(exc).__name__)
+        raise HTTPException(502, "Unable to connect to upstream stream") from exc
+    content_type = upstream.headers.get("Content-Type") or "video/mp2t"
+    headers = {"Cache-Control": "no-store"}
+    content_length = upstream.headers.get("Content-Length")
+    if content_length:
+        headers["Content-Length"] = content_length
+    content_encoding = upstream.headers.get("Content-Encoding")
+    if content_encoding:
+        headers["Content-Encoding"] = content_encoding
+    return StreamingResponse(_iter_upstream(upstream), media_type=content_type, headers=headers)
+
+
+@app.get("/live/{stream_path:path}", name="live_stream")
+async def live_stream(request: Request, stream_path: str) -> StreamingResponse:
+    try:
+        username, remainder = stream_path.split("/", 1)
+        password, filename = remainder.rsplit("/", 1)
+        stream_id_text, extension = filename.rsplit(".", 1)
+        stream_id = int(stream_id_text)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(400, "Invalid live stream path") from exc
+    if not await authenticator.verify(request, username, password):
+        raise HTTPException(401, "Invalid username or password")
+    if extension != "ts":
+        raise HTTPException(400, "Unsupported stream format")
+    snapshot = await _get_catalog()
+    stream = snapshot.streams_by_id.get(stream_id)
+    if stream is None or stream not in _visible_streams(username, snapshot):
+        raise HTTPException(404, "Stream not found")
+    return await _proxy_url(_resolve_upstream(stream, extension))
+
+
+@app.get("/xmltv.php")
+async def xmltv(
+    request: Request,
+    username: str = Query(""),
+    password: str = Query(""),
+) -> Response:
+    if not await authenticator.verify(request, username, password):
+        raise HTTPException(401, "Invalid username or password")
+    snapshot = await _get_catalog()
+    streams = _visible_streams(username, snapshot)
+    try:
+        content = await asyncio.to_thread(
+            build_filtered_xmltv,
+            cache.CACHE_DIR / "epg.db",
+            streams,
+        )
+    except EpgUnavailableError as exc:
+        raise HTTPException(503, str(exc)) from exc
+    return Response(
+        content,
+        media_type="application/xml",
+        headers={"Cache-Control": "private, max-age=300"},
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    parser = argparse.ArgumentParser(description="neTV native-player gateway")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("NETV_GATEWAY_PORT", "8100")),
+    )
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.debug else getattr(
+        logging,
+        os.environ.get("LOG_LEVEL", "INFO").upper(),
+        logging.INFO,
+    )
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+        datefmt="%H:%M:%S",
+        force=True,
+    )
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=args.port,
+        access_log=False,
+        log_level="debug" if args.debug else "info",
+        log_config=None,
+        proxy_headers=True,
+        forwarded_allow_ips=os.environ.get(
+            "NETV_GATEWAY_TRUSTED_PROXIES",
+            "127.0.0.1",
+        ),
+    )

--- a/gateway_catalog.py
+++ b/gateway_catalog.py
@@ -1,0 +1,361 @@
+"""Native-player catalog built from neTV's configured IPTV sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import hashlib
+import json
+import logging
+import pathlib
+import threading
+import time
+import urllib.error
+import urllib.parse
+
+from m3u import fetch_source_live_data
+from util import atomic_write_json
+
+import cache
+
+
+log = logging.getLogger(__name__)
+_FAILED_LOAD_RETRY_SECONDS = 60
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayStream:
+    """A public stream entry and its private upstream mapping."""
+
+    local_id: int
+    source_id: str
+    source_type: str
+    upstream_id: str
+    direct_url: str
+    access_group_ids: tuple[str, ...]
+    public: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogSnapshot:
+    categories: list[dict[str, Any]]
+    category_access_ids: dict[str, str]
+    streams: list[GatewayStream]
+    streams_by_id: dict[int, GatewayStream]
+
+
+class StreamIdRegistry:
+    """Persist stable integer IDs for source-specific upstream stream IDs."""
+
+    def __init__(self, path: pathlib.Path | None = None) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        self._loaded = False
+        self._ids: dict[str, int] = {}
+        self._next_id = 1
+
+    @property
+    def path(self) -> pathlib.Path:
+        return self._path or cache.CACHE_DIR / "gateway_stream_ids.json"
+
+    def _load(self) -> None:
+        if self._loaded:
+            return
+        try:
+            raw = json.loads(self.path.read_text())
+            if not isinstance(raw, dict) or not isinstance(raw.get("ids"), dict):
+                raise ValueError("registry must contain an object-valued 'ids' field")
+            ids = raw["ids"]
+            self._ids = {
+                str(key): int(value)
+                for key, value in ids.items()
+                if isinstance(value, int) and value > 0
+            }
+            if len(self._ids) != len(ids) or len(set(self._ids.values())) != len(self._ids):
+                raise ValueError("registry contains invalid or duplicate IDs")
+            self._next_id = max(self._ids.values(), default=0) + 1
+        except FileNotFoundError:
+            pass
+        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            log.error("Invalid gateway stream ID registry: %s", exc)
+            raise RuntimeError("Invalid gateway stream ID registry") from exc
+        self._loaded = True
+
+    def _save(self) -> None:
+        atomic_write_json(self.path, {"ids": dict(sorted(self._ids.items()))})
+
+    def get_or_create(self, key: str) -> int:
+        return self.get_or_create_many([key])[key]
+
+    def get_or_create_many(self, keys: list[str]) -> dict[str, int]:
+        with self._lock:
+            self._load()
+            changed = False
+            for key in keys:
+                if key in self._ids:
+                    continue
+                self._ids[key] = self._next_id
+                self._next_id += 1
+                changed = True
+            if changed:
+                self._save()
+            return {key: self._ids[key] for key in keys}
+
+
+class GatewayCatalog:
+    """Load and cache a sanitized live catalog for native players."""
+
+    def __init__(
+        self,
+        registry: StreamIdRegistry | None = None,
+        ttl_seconds: int = cache.LIVE_CACHE_TTL,
+    ) -> None:
+        self._registry = registry or StreamIdRegistry()
+        self._ttl_seconds = ttl_seconds
+        self._lock = threading.Lock()
+        self._snapshot: CatalogSnapshot | None = None
+        self._loaded_at = 0.0
+
+    def get(self, force: bool = False) -> CatalogSnapshot:
+        if (
+            not force
+            and self._snapshot is not None
+            and time.monotonic() - self._loaded_at < self._ttl_seconds
+        ):
+            return self._snapshot
+        with self._lock:
+            if (
+                not force
+                and self._snapshot is not None
+                and time.monotonic() - self._loaded_at < self._ttl_seconds
+            ):
+                return self._snapshot
+            candidate, had_errors = self._load()
+            if had_errors and self._snapshot is not None:
+                log.warning("Gateway catalog refresh failed; retaining the previous snapshot")
+                self._loaded_at = (
+                    time.monotonic()
+                    - self._ttl_seconds
+                    + min(_FAILED_LOAD_RETRY_SECONDS, self._ttl_seconds)
+                )
+                return self._snapshot
+            self._snapshot = candidate
+            self._loaded_at = (
+                time.monotonic()
+                if not had_errors
+                else time.monotonic()
+                - self._ttl_seconds
+                + min(_FAILED_LOAD_RETRY_SECONDS, self._ttl_seconds)
+            )
+            return self._snapshot
+
+    def _load(self) -> tuple[CatalogSnapshot, bool]:
+        categories: list[dict[str, Any]] = []
+        category_access_ids: dict[str, str] = {}
+        streams: list[GatewayStream] = []
+        had_errors = False
+
+        for source in cache.get_sources():
+            if source.type not in ("xtream", "m3u"):
+                continue
+            try:
+                source_categories, source_streams, _, _ = fetch_source_live_data(
+                    source,
+                    persist_epg_url=False,
+                )
+            except (KeyError, OSError, TypeError, ValueError, urllib.error.URLError) as exc:
+                had_errors = True
+                log.error(
+                    "Gateway failed to load source %s (%s)",
+                    source.name,
+                    type(exc).__name__,
+                )
+                continue
+
+            category_values = {
+                str(category.get("category_id"))
+                for category in source_categories
+                if category.get("category_id") not in (None, "")
+            }
+            category_values.update(
+                str(category_id)
+                for stream in source_streams
+                for category_id in stream.get("category_ids") or []
+                if category_id not in (None, "")
+            )
+            uncategorized_id = f"{source.id}_gateway_uncategorized"
+            needs_uncategorized = any(
+                not (stream.get("category_ids") or []) for stream in source_streams
+            )
+            if needs_uncategorized:
+                category_values.add(uncategorized_id)
+            category_keys = {
+                category_id: f"{source.id}:category:{category_id}"
+                for category_id in category_values
+            }
+            category_local_ids = self._registry.get_or_create_many(list(category_keys.values()))
+            category_id_map = {
+                category_id: str(category_local_ids[key])
+                for category_id, key in category_keys.items()
+            }
+            category_access_ids.update(
+                {
+                    public_id: source_category_id
+                    for source_category_id, public_id in category_id_map.items()
+                    if source_category_id != uncategorized_id
+                }
+            )
+            categories.extend(self._public_categories(source_categories, category_id_map))
+            if needs_uncategorized:
+                categories.append(
+                    {
+                        "category_id": category_id_map[uncategorized_id],
+                        "category_name": "Uncategorized",
+                        "parent_id": 0,
+                    }
+                )
+            registry_entries: list[tuple[dict[str, Any], str]] = []
+            key_occurrences: dict[str, int] = {}
+            for stream in source_streams:
+                if stream.get("stream_id") in (None, ""):
+                    continue
+                base_key = self._stream_registry_key(source.id, source.type, stream)
+                occurrence = key_occurrences.get(base_key, 0)
+                key_occurrences[base_key] = occurrence + 1
+                key = (
+                    base_key
+                    if occurrence == 0
+                    else f"{base_key}:duplicate:{occurrence + 1}"
+                )
+                registry_entries.append((stream, key))
+            registry_keys = [key for _, key in registry_entries]
+            local_ids = self._registry.get_or_create_many(registry_keys)
+            for stream, key in registry_entries:
+                local_id = local_ids[key]
+                mapped = self._map_stream(
+                    source.id,
+                    source.type,
+                    stream,
+                    local_id,
+                    category_id_map,
+                    uncategorized_id,
+                    category_id_map.get(uncategorized_id, ""),
+                )
+                if mapped is not None:
+                    streams.append(mapped)
+
+        return (
+            CatalogSnapshot(
+                categories=categories,
+                category_access_ids=category_access_ids,
+                streams=streams,
+                streams_by_id={stream.local_id: stream for stream in streams},
+            ),
+            had_errors,
+        )
+
+    @staticmethod
+    def _stream_registry_key(
+        source_id: str,
+        source_type: str,
+        stream: dict[str, Any],
+    ) -> str:
+        upstream_id = str(stream.get("stream_id", ""))
+        if source_type != "m3u":
+            return f"{source_id}:live:{upstream_id}"
+        direct_url = str(stream.get("direct_url") or "")
+        epg_channel_id = str(stream.get("epg_channel_id") or "")
+        name = str(stream.get("name") or "")
+        parsed_url = urllib.parse.urlparse(direct_url)
+        stable_url = urllib.parse.urlunparse(
+            (parsed_url.scheme, parsed_url.netloc, parsed_url.path, "", "", "")
+        )
+        identity = f"{epg_channel_id}\0{name}\0{stable_url}"
+        if not epg_channel_id and not name and not stable_url:
+            identity = upstream_id
+        digest = hashlib.sha256(identity.encode()).hexdigest()
+        return f"{source_id}:live-url:{digest}"
+
+    @staticmethod
+    def _public_categories(
+        categories: list[dict[str, Any]],
+        category_id_map: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "category_id": category_id_map[str(category["category_id"])],
+                "category_name": str(category.get("category_name", "Uncategorized")),
+                "parent_id": 0,
+            }
+            for category in categories
+            if str(category.get("category_id", "")) in category_id_map
+        ]
+
+    def _map_stream(
+        self,
+        source_id: str,
+        source_type: str,
+        stream: dict[str, Any],
+        local_id: int,
+        category_id_map: dict[str, str],
+        uncategorized_source_id: str,
+        uncategorized_public_id: str,
+    ) -> GatewayStream | None:
+        upstream_id = str(stream.get("stream_id", ""))
+        if not upstream_id:
+            return None
+        source_category_ids = [str(value) for value in stream.get("category_ids") or []]
+        category_ids = [
+            category_id_map[value] for value in source_category_ids if value in category_id_map
+        ]
+        source_category_id = str(stream.get("category_id", ""))
+        access_group_ids = tuple(source_category_ids)
+        fallback_source_id = (
+            source_category_id
+            if source_category_id in category_id_map
+            else uncategorized_source_id
+        )
+        category_id = (
+            category_ids[0]
+            if category_ids
+            else category_id_map.get(fallback_source_id, uncategorized_public_id)
+        )
+        if not category_ids and category_id:
+            category_ids = [category_id]
+            access_group_ids = (
+                (fallback_source_id,)
+                if fallback_source_id != uncategorized_source_id
+                else ()
+            )
+        access_group_ids = tuple(value for value in access_group_ids if value)
+        public = {
+            "num": stream.get("num", local_id),
+            "name": str(stream.get("name", "Unknown")),
+            "stream_type": "live",
+            "stream_id": local_id,
+            "stream_icon": str(stream.get("stream_icon") or ""),
+            "epg_channel_id": str(stream.get("epg_channel_id") or ""),
+            "added": str(stream.get("added") or ""),
+            "category_id": category_id,
+            "category_ids": category_ids or ([category_id] if category_id else []),
+            "custom_sid": str(stream.get("custom_sid") or ""),
+            "tv_archive": _safe_int(stream.get("tv_archive")),
+            "tv_archive_duration": _safe_int(stream.get("tv_archive_duration")),
+        }
+        return GatewayStream(
+            local_id=local_id,
+            source_id=source_id,
+            source_type=source_type,
+            upstream_id=upstream_id,
+            direct_url=str(stream.get("direct_url") or ""),
+            access_group_ids=access_group_ids,
+            public=public,
+        )

--- a/gateway_epg.py
+++ b/gateway_epg.py
@@ -1,0 +1,181 @@
+"""Filtered XMLTV generation for native-player users."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pathlib
+import sqlite3
+import xml.etree.ElementTree as ET
+
+from gateway_catalog import GatewayStream
+
+
+_SQL_CHUNK_SIZE = 400
+_GUIDE_HISTORY_HOURS = 12
+_GUIDE_DAYS = 7
+
+
+class EpgUnavailableError(RuntimeError):
+    """Raised when the shared neTV EPG database is not ready."""
+
+
+def _xml_text(value: object) -> str:
+    text = str(value or "")
+    return "".join(
+        char
+        for char in text
+        if char in ("\t", "\n", "\r") or ord(char) >= 0x20
+    )
+
+
+def _xmltv_time(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, tz=UTC).strftime("%Y%m%d%H%M%S +0000")
+
+
+def _chunks(values: list[str]) -> list[list[str]]:
+    return [
+        values[index : index + _SQL_CHUNK_SIZE]
+        for index in range(0, len(values), _SQL_CHUNK_SIZE)
+    ]
+
+
+def build_filtered_xmltv(
+    database_path: pathlib.Path,
+    streams: list[GatewayStream],
+    now: datetime | None = None,
+) -> bytes:
+    """Build XMLTV containing only guide entries for the supplied streams."""
+    stream_channels: dict[str, dict[str, object]] = {}
+    for stream in streams:
+        channel_id = str(stream.public.get("epg_channel_id") or "")
+        if not channel_id:
+            continue
+        channel = stream_channels.setdefault(
+            channel_id,
+            {
+                "name": stream.public.get("name") or channel_id,
+                "icon": stream.public.get("stream_icon") or "",
+                "source_ids": set(),
+            },
+        )
+        source_ids = channel["source_ids"]
+        if isinstance(source_ids, set):
+            source_ids.add(stream.source_id)
+
+    root = ET.Element("tv", {"generator-info-name": "neTV"})
+    if not stream_channels:
+        return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    if not database_path.exists():
+        raise EpgUnavailableError("EPG database is not ready")
+
+    try:
+        connection = sqlite3.connect(f"file:{database_path}?mode=ro", uri=True, timeout=10)
+        connection.row_factory = sqlite3.Row
+    except sqlite3.Error as exc:
+        raise EpgUnavailableError("EPG database is not available") from exc
+
+    channel_ids = list(stream_channels)
+    current = now or datetime.now(UTC)
+    start_timestamp = (current - timedelta(hours=_GUIDE_HISTORY_HOURS)).timestamp()
+    stop_timestamp = (current + timedelta(days=_GUIDE_DAYS)).timestamp()
+    programs: list[sqlite3.Row] = []
+    try:
+        connection.execute("PRAGMA query_only=ON")
+        for chunk in _chunks(channel_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            channel_rows = connection.execute(
+                f"""
+                SELECT channels.id, channels.name, icons.url
+                FROM channels
+                LEFT JOIN icons ON icons.channel_id = channels.id
+                WHERE channels.id IN ({placeholders})
+                """,
+                chunk,
+            ).fetchall()
+            for row in channel_rows:
+                stream_channels[row["id"]]["name"] = row["name"] or row["id"]
+                if row["url"]:
+                    stream_channels[row["id"]]["icon"] = row["url"]
+
+            programs.extend(
+                connection.execute(
+                    f"""
+                    SELECT channel_id, title, start_ts, stop_ts, desc, source_id
+                    FROM programs
+                    WHERE channel_id IN ({placeholders})
+                      AND stop_ts > ?
+                      AND start_ts < ?
+                    ORDER BY channel_id, start_ts
+                    """,
+                    [*chunk, start_timestamp, stop_timestamp],
+                ).fetchall()
+            )
+    except sqlite3.Error as exc:
+        raise EpgUnavailableError("EPG database schema is not ready") from exc
+    finally:
+        connection.close()
+
+    for channel_id, metadata in stream_channels.items():
+        channel_element = ET.SubElement(root, "channel", {"id": _xml_text(channel_id)})
+        ET.SubElement(channel_element, "display-name").text = _xml_text(metadata["name"])
+        icon = _xml_text(metadata["icon"])
+        if icon:
+            ET.SubElement(channel_element, "icon", {"src": icon})
+
+    selected_programs: dict[str, list[sqlite3.Row]] = {}
+    for row in programs:
+        channel = stream_channels.get(row["channel_id"])
+        if channel is None:
+            continue
+        preferred_sources = channel["source_ids"]
+        channel_programs = selected_programs.setdefault(row["channel_id"], [])
+        overlap_index = next(
+            (
+                index
+                for index, existing in enumerate(channel_programs)
+                if row["start_ts"] < existing["stop_ts"]
+                and row["stop_ts"] > existing["start_ts"]
+            ),
+            None,
+        )
+        if overlap_index is not None:
+            overlapping = [
+                existing
+                for existing in channel_programs
+                if row["start_ts"] < existing["stop_ts"]
+                and row["stop_ts"] > existing["start_ts"]
+            ]
+            if (
+                isinstance(preferred_sources, set)
+                and row["source_id"] in preferred_sources
+                and not any(
+                    existing["source_id"] in preferred_sources
+                    for existing in overlapping
+                )
+            ):
+                channel_programs[:] = [
+                    existing
+                    for existing in channel_programs
+                    if existing not in overlapping
+                ]
+                channel_programs.append(row)
+            continue
+        channel_programs.append(row)
+
+    for channel_programs in selected_programs.values():
+        for row in sorted(channel_programs, key=lambda program: program["start_ts"]):
+            programme = ET.SubElement(
+                root,
+                "programme",
+                {
+                    "start": _xmltv_time(row["start_ts"]),
+                    "stop": _xmltv_time(row["stop_ts"]),
+                    "channel": _xml_text(row["channel_id"]),
+                },
+            )
+            ET.SubElement(programme, "title").text = _xml_text(row["title"] or "Unknown")
+            if row["desc"]:
+                ET.SubElement(programme, "desc").text = _xml_text(row["desc"])
+
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)

--- a/gateway_epg_test.py
+++ b/gateway_epg_test.py
@@ -1,0 +1,239 @@
+"""Tests for filtered native-player XMLTV output."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import sqlite3
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from gateway_catalog import GatewayStream
+from gateway_epg import EpgUnavailableError, build_filtered_xmltv
+
+
+def _stream(
+    local_id: int,
+    channel_id: str,
+    source_id: str = "source-a",
+) -> GatewayStream:
+    return GatewayStream(
+        local_id=local_id,
+        source_id=source_id,
+        source_type="xtream",
+        upstream_id=str(local_id),
+        direct_url="",
+        access_group_ids=("category-a",),
+        public={
+            "name": f"Channel {local_id}",
+            "stream_icon": f"https://images.example/{local_id}.png",
+            "epg_channel_id": channel_id,
+            "category_id": "1",
+            "category_ids": ["1"],
+        },
+    )
+
+
+def _create_epg_database(path: Path, now: datetime) -> None:
+    connection = sqlite3.connect(path)
+    connection.executescript("""
+        CREATE TABLE channels (id TEXT PRIMARY KEY, name TEXT, source_id TEXT);
+        CREATE TABLE icons (channel_id TEXT PRIMARY KEY, url TEXT);
+        CREATE TABLE programs (
+            id INTEGER PRIMARY KEY,
+            channel_id TEXT,
+            title TEXT,
+            start_ts REAL,
+            stop_ts REAL,
+            desc TEXT,
+            source_id TEXT
+        );
+    """)
+    connection.executemany(
+        "INSERT INTO channels (id, name, source_id) VALUES (?, ?, ?)",
+        [
+            ("allowed.channel", "Allowed Channel", "source-a"),
+            ("blocked.channel", "Blocked Channel", "source-a"),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO programs (channel_id, title, start_ts, stop_ts, desc, source_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (
+                "allowed.channel",
+                "Allowed Programme",
+                now.timestamp(),
+                (now + timedelta(hours=1)).timestamp(),
+                "Allowed description",
+                "source-a",
+            ),
+            (
+                "blocked.channel",
+                "Blocked Programme",
+                now.timestamp(),
+                (now + timedelta(hours=1)).timestamp(),
+                "Blocked description",
+                "source-a",
+            ),
+            (
+                "allowed.channel",
+                "Wrong Source Programme",
+                now.timestamp(),
+                (now + timedelta(hours=1)).timestamp(),
+                "",
+                "source-b",
+            ),
+            (
+                "allowed.channel",
+                "Standalone EPG Programme",
+                (now + timedelta(hours=1)).timestamp(),
+                (now + timedelta(hours=2)).timestamp(),
+                "",
+                "epg-source",
+            ),
+            (
+                "allowed.channel",
+                "Expired Programme",
+                (now - timedelta(days=2)).timestamp(),
+                (now - timedelta(days=2, hours=-1)).timestamp(),
+                "",
+                "source-a",
+            ),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+
+def test_filtered_xmltv_contains_only_allowed_current_programs(tmp_path: Path):
+    now = datetime(2026, 8, 29, 18, tzinfo=UTC)
+    database = tmp_path / "epg.db"
+    _create_epg_database(database, now)
+
+    content = build_filtered_xmltv(
+        database,
+        [_stream(1, "allowed.channel")],
+        now=now,
+    )
+    root = ET.fromstring(content)
+
+    assert [channel.get("id") for channel in root.findall("channel")] == [
+        "allowed.channel"
+    ]
+    assert [programme.findtext("title") for programme in root.findall("programme")] == [
+        "Allowed Programme",
+        "Standalone EPG Programme",
+    ]
+    assert b"blocked.channel" not in content
+    assert b"Wrong Source Programme" not in content
+    assert b"Expired Programme" not in content
+
+
+def test_filtered_xmltv_accepts_nonoverlapping_standalone_epg_programme(tmp_path: Path):
+    now = datetime(2026, 8, 29, 18, tzinfo=UTC)
+    database = tmp_path / "epg.db"
+    _create_epg_database(database, now)
+
+    content = build_filtered_xmltv(
+        database,
+        [_stream(1, "allowed.channel")],
+        now=now,
+    )
+    titles = [
+        programme.findtext("title")
+        for programme in ET.fromstring(content).findall("programme")
+    ]
+
+    assert titles == ["Allowed Programme", "Standalone EPG Programme"]
+
+
+def test_filtered_xmltv_preferred_programme_replaces_all_overlaps(tmp_path: Path):
+    now = datetime(2026, 8, 29, 18, tzinfo=UTC)
+    database = tmp_path / "epg.db"
+    _create_epg_database(database, now)
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO channels (id, name, source_id) VALUES (?, ?, ?)",
+        ("split.channel", "Split Channel", "source-a"),
+    )
+    connection.executemany(
+        "INSERT INTO programs (channel_id, title, start_ts, stop_ts, desc, source_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (
+                "split.channel",
+                "External Part One",
+                now.timestamp(),
+                (now + timedelta(minutes=30)).timestamp(),
+                "",
+                "epg-source",
+            ),
+            (
+                "split.channel",
+                "External Part Two",
+                (now + timedelta(minutes=30)).timestamp(),
+                (now + timedelta(hours=1)).timestamp(),
+                "",
+                "epg-source",
+            ),
+            (
+                "split.channel",
+                "Preferred Full Programme",
+                (now + timedelta(minutes=15)).timestamp(),
+                (now + timedelta(hours=1, minutes=15)).timestamp(),
+                "",
+                "source-a",
+            ),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+    content = build_filtered_xmltv(
+        database,
+        [_stream(2, "split.channel")],
+        now=now,
+    )
+    titles = [
+        programme.findtext("title")
+        for programme in ET.fromstring(content).findall("programme")
+    ]
+
+    assert titles == ["Preferred Full Programme"]
+
+
+def test_filtered_xmltv_uses_stream_metadata_without_channel_row(tmp_path: Path):
+    now = datetime(2026, 8, 29, 18, tzinfo=UTC)
+    database = tmp_path / "epg.db"
+    _create_epg_database(database, now)
+
+    content = build_filtered_xmltv(
+        database,
+        [_stream(3, "missing.channel")],
+        now=now,
+    )
+    channel = ET.fromstring(content).find("channel")
+
+    assert channel is not None
+    assert channel.get("id") == "missing.channel"
+    assert channel.findtext("display-name") == "Channel 3"
+
+
+def test_filtered_xmltv_returns_empty_feed_without_channel_ids(tmp_path: Path):
+    content = build_filtered_xmltv(
+        tmp_path / "missing.db",
+        [_stream(1, "")],
+    )
+
+    assert ET.fromstring(content).findall("channel") == []
+
+
+def test_filtered_xmltv_requires_epg_database(tmp_path: Path):
+    with pytest.raises(EpgUnavailableError, match="not ready"):
+        build_filtered_xmltv(
+            tmp_path / "missing.db",
+            [_stream(1, "allowed.channel")],
+        )

--- a/gateway_test.py
+++ b/gateway_test.py
@@ -1,0 +1,594 @@
+"""Tests for the native-player gateway."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import json
+import urllib.error
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from gateway_catalog import CatalogSnapshot, GatewayCatalog, GatewayStream, StreamIdRegistry
+
+import auth
+import cache
+import gateway
+import gateway_catalog
+
+
+class _FakeCatalog:
+    def __init__(self, snapshot: CatalogSnapshot) -> None:
+        self.snapshot = snapshot
+
+    def get(self) -> CatalogSnapshot:
+        return self.snapshot
+
+
+@pytest.fixture
+def gateway_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    settings_file = tmp_path / "server_settings.json"
+    users_dir = tmp_path / "users"
+    users_dir.mkdir()
+    monkeypatch.setattr(auth, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(auth, "SERVER_SETTINGS_FILE", settings_file)
+    monkeypatch.setattr(auth, "USERS_DIR", users_dir)
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cache, "SERVER_SETTINGS_FILE", settings_file)
+    monkeypatch.setattr(cache, "USERS_DIR", users_dir)
+    auth.create_user("player", "local-pass")
+    monkeypatch.setattr(gateway, "authenticator", gateway.GatewayAuthenticator())
+
+    public = {
+        "num": 1,
+        "name": "News One",
+        "stream_type": "live",
+        "stream_id": 41,
+        "stream_icon": "https://images.example/news.png",
+        "epg_channel_id": "news.one",
+        "added": "",
+        "category_id": "src_1_news",
+        "category_ids": ["src_1_news"],
+        "custom_sid": "",
+        "tv_archive": 0,
+        "tv_archive_duration": 0,
+    }
+    stream = GatewayStream(
+        local_id=41,
+        source_id="src_1",
+        source_type="xtream",
+        upstream_id="987",
+        direct_url="",
+        access_group_ids=("src_1_news",),
+        public=public,
+    )
+    snapshot = CatalogSnapshot(
+        categories=[
+            {
+                "category_id": "src_1_news",
+                "category_name": "News",
+                "parent_id": 0,
+            }
+        ],
+        category_access_ids={"src_1_news": "src_1_news"},
+        streams=[stream],
+        streams_by_id={41: stream},
+    )
+    monkeypatch.setattr(gateway, "catalog", _FakeCatalog(snapshot))
+    return TestClient(gateway.app), snapshot
+
+
+def test_healthcheck_does_not_require_auth(gateway_client):
+    client, _ = gateway_client
+    assert client.get("/healthz").json() == {"status": "ok"}
+
+
+def test_player_api_rejects_invalid_credentials(gateway_client):
+    client, _ = gateway_client
+    response = client.get(
+        "/player_api.php",
+        params={"username": "player", "password": "wrong"},
+    )
+    assert response.status_code == 200
+    assert response.json()["user_info"]["auth"] == 0
+
+
+def test_player_api_exposes_active_server_profile(gateway_client):
+    client, _ = gateway_client
+    response = client.get(
+        "/player_api.php",
+        params={"username": "player", "password": "local-pass"},
+    )
+    assert response.status_code == 200
+    assert response.json()["user_info"] == {
+        "username": "player",
+        "password": "local-pass",
+        "message": "neTV native-player gateway",
+        "auth": 1,
+        "status": "Active",
+        "exp_date": None,
+        "is_trial": "0",
+        "active_cons": "0",
+        "created_at": "0",
+        "max_connections": "1",
+        "allowed_output_formats": ["ts"],
+    }
+
+
+def test_server_profile_uses_configured_public_url(
+    gateway_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client, _ = gateway_client
+    monkeypatch.setenv("NETV_GATEWAY_PUBLIC_URL", "https://tv.example:8443")
+
+    response = client.get(
+        "/player_api.php",
+        params={"username": "player", "password": "local-pass"},
+    )
+
+    assert response.json()["server_info"] == {
+        "url": "tv.example",
+        "port": "8443",
+        "https_port": "8443",
+        "server_protocol": "https",
+        "rtmp_port": "0",
+        "timezone": "UTC",
+        "timestamp_now": response.json()["server_info"]["timestamp_now"],
+        "time_now": response.json()["server_info"]["time_now"],
+    }
+
+
+def test_successful_authentication_is_cached(
+    gateway_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client, _ = gateway_client
+    verify_password = MagicMock(return_value=True)
+    monkeypatch.setattr(auth, "verify_password", verify_password)
+
+    for _ in range(2):
+        response = client.get(
+            "/player_api.php",
+            params={"username": "player", "password": "local-pass"},
+        )
+        assert response.status_code == 200
+
+    verify_password.assert_called_once_with("player", "local-pass")
+
+
+def test_failed_authentication_is_rate_limited(gateway_client):
+    client, _ = gateway_client
+    params = {"username": "player", "password": "wrong"}
+
+    for _ in range(10):
+        assert client.get("/player_api.php", params=params).status_code == 200
+
+    assert client.get("/player_api.php", params=params).status_code == 429
+
+
+def test_success_cache_is_checked_before_client_rate_limit(
+    gateway_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client, _ = gateway_client
+    valid = {"username": "player", "password": "local-pass"}
+    assert client.get("/player_api.php", params=valid).status_code == 200
+    monkeypatch.setattr(gateway, "_MAX_LOGIN_FAILURES", 1)
+    assert client.get(
+        "/player_api.php",
+        params={"username": "player", "password": "wrong"},
+    ).status_code == 200
+
+    assert client.get("/player_api.php", params=valid).status_code == 200
+
+
+def test_player_api_exposes_local_live_catalog(gateway_client):
+    client, _ = gateway_client
+    response = client.get(
+        "/player_api.php",
+        params={
+            "username": "player",
+            "password": "local-pass",
+            "action": "get_live_streams",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "num": 1,
+            "name": "News One",
+            "stream_type": "live",
+            "stream_id": 41,
+            "stream_icon": "https://images.example/news.png",
+            "epg_channel_id": "news.one",
+            "added": "",
+            "category_id": "src_1_news",
+            "category_ids": ["src_1_news"],
+            "custom_sid": "",
+            "tv_archive": 0,
+            "tv_archive_duration": 0,
+        }
+    ]
+
+
+def test_playlist_contains_only_local_playback_urls(gateway_client):
+    client, _ = gateway_client
+    response = client.get(
+        "/get.php",
+        params={"username": "player", "password": "local-pass", "output": "ts"},
+    )
+    assert response.status_code == 200
+    assert "http://testserver/live/player/local-pass/41.ts" in response.text
+    assert "provider.example/live" not in response.text
+    assert 'group-title="News"' in response.text
+
+
+def test_user_category_restrictions_apply_to_gateway(gateway_client):
+    client, _ = gateway_client
+    assert auth.set_user_limits("player", unavailable_groups=["cat:src_1_news"])
+    response = client.get(
+        "/player_api.php",
+        params={
+            "username": "player",
+            "password": "local-pass",
+            "action": "get_live_streams",
+        },
+    )
+    assert response.json() == []
+
+
+def test_uncategorized_streams_hidden_for_restricted_user(
+    gateway_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _, snapshot = gateway_client
+    stream = snapshot.streams[0]
+    uncategorized = GatewayStream(
+        local_id=stream.local_id,
+        source_id=stream.source_id,
+        source_type=stream.source_type,
+        upstream_id=stream.upstream_id,
+        direct_url=stream.direct_url,
+        access_group_ids=(),
+        public={**stream.public, "category_id": "99", "category_ids": ["99"]},
+    )
+    restricted_snapshot = CatalogSnapshot(
+        categories=[{"category_id": "99", "category_name": "Uncategorized", "parent_id": 0}],
+        category_access_ids={},
+        streams=[uncategorized],
+        streams_by_id={uncategorized.local_id: uncategorized},
+    )
+    monkeypatch.setattr(
+        auth,
+        "get_user_limits",
+        lambda _username: {"unavailable_groups": ["cat:some-other-category"]},
+    )
+
+    assert gateway._allowed_category_ids("player", restricted_snapshot) == set()
+    assert gateway._visible_streams("player", restricted_snapshot) == []
+
+
+def test_live_stream_proxies_resolved_upstream(gateway_client, monkeypatch: pytest.MonkeyPatch):
+    client, _ = gateway_client
+    upstream = MagicMock()
+    upstream.headers = {"Content-Type": "video/mp2t"}
+    upstream.read.side_effect = [b"video-data", b""]
+    fake_xtream = MagicMock()
+    fake_xtream.build_stream_url.return_value = (
+        "https://provider.example/live/remote-user/remote-pass/987.ts"
+    )
+    monkeypatch.setattr(gateway, "get_xtream_client_by_source", lambda _source_id: fake_xtream)
+    open_mock = MagicMock(return_value=upstream)
+    monkeypatch.setattr(gateway, "safe_urlopen", open_mock)
+
+    response = client.get("/live/player/local-pass/41.ts")
+
+    assert response.status_code == 200
+    assert response.content == b"video-data"
+    fake_xtream.build_stream_url.assert_called_once_with("live", 987, "ts")
+    assert open_mock.call_args.args[0].endswith("/987.ts")
+    upstream.close.assert_called_once()
+
+
+def test_live_stream_enforces_category_restrictions(
+    gateway_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client, _ = gateway_client
+    assert auth.set_user_limits("player", unavailable_groups=["cat:src_1_news"])
+    open_mock = MagicMock()
+    monkeypatch.setattr(gateway, "safe_urlopen", open_mock)
+
+    response = client.get("/live/player/local-pass/41.ts")
+
+    assert response.status_code == 404
+    open_mock.assert_not_called()
+
+
+def test_xmltv_builds_feed_for_visible_streams(
+    gateway_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client, snapshot = gateway_client
+    build_mock = MagicMock(return_value=b'<?xml version="1.0"?><tv />')
+    monkeypatch.setattr(gateway, "build_filtered_xmltv", build_mock)
+
+    response = client.get(
+        "/xmltv.php",
+        params={"username": "player", "password": "local-pass"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/xml")
+    assert build_mock.call_args.args[1] == snapshot.streams
+
+
+def test_xmltv_enforces_category_restrictions(
+    gateway_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client, _ = gateway_client
+    assert auth.set_user_limits("player", unavailable_groups=["cat:src_1_news"])
+    build_mock = MagicMock(return_value=b'<?xml version="1.0"?><tv />')
+    monkeypatch.setattr(gateway, "build_filtered_xmltv", build_mock)
+
+    response = client.get(
+        "/xmltv.php",
+        params={"username": "player", "password": "local-pass"},
+    )
+
+    assert response.status_code == 200
+    assert build_mock.call_args.args[1] == []
+
+
+def test_stream_id_registry_is_stable(tmp_path: Path):
+    path = tmp_path / "stream_ids.json"
+    first = StreamIdRegistry(path)
+    assigned = first.get_or_create_many(["source-a:live:7", "source-b:live:7"])
+
+    second = StreamIdRegistry(path)
+    assert second.get_or_create("source-a:live:7") == assigned["source-a:live:7"]
+    assert second.get_or_create("source-b:live:7") == assigned["source-b:live:7"]
+    assert assigned["source-a:live:7"] != assigned["source-b:live:7"]
+
+
+def test_stream_id_registry_rejects_invalid_existing_file(tmp_path: Path):
+    path = tmp_path / "stream_ids.json"
+    path.write_text("[]")
+
+    with pytest.raises(RuntimeError, match="Invalid gateway stream ID registry"):
+        StreamIdRegistry(path).get_or_create("source-a:live:7")
+
+    assert path.read_text() == "[]"
+
+
+def test_catalog_removes_upstream_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    source = SimpleNamespace(
+        id="source-a",
+        name="Provider",
+        type="xtream",
+        url="https://provider.example",
+        username="remote-user",
+        password="remote-password",
+        epg_enabled=True,
+    )
+    monkeypatch.setattr(cache, "get_sources", lambda: [source])
+    monkeypatch.setattr(
+        gateway_catalog,
+        "fetch_source_live_data",
+        lambda _source, **_kwargs: (
+            [{"category_id": "source-a_9", "category_name": "News", "parent_id": 0}],
+            [
+                {
+                    "stream_id": 7,
+                    "name": "News",
+                    "category_ids": ["source-a_9"],
+                    "source_username": "remote-user",
+                    "source_password": "remote-password",
+                    "source_url": "https://provider.example",
+                }
+            ],
+            "https://provider.example/xmltv.php",
+            120,
+        ),
+    )
+    snapshot = GatewayCatalog(
+        registry=StreamIdRegistry(tmp_path / "ids.json"),
+        ttl_seconds=60,
+    ).get()
+
+    encoded = json.dumps(snapshot.streams[0].public)
+    assert snapshot.categories[0]["category_id"].isdigit()
+    assert snapshot.streams[0].public["category_id"] == snapshot.categories[0]["category_id"]
+    assert "remote-user" not in encoded
+    assert "remote-password" not in encoded
+    assert "provider.example" not in encoded
+
+
+def test_catalog_assigns_uncategorized_streams_numeric_category(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source = SimpleNamespace(
+        id="source-a",
+        name="Provider",
+        type="xtream",
+        epg_enabled=False,
+    )
+    monkeypatch.setattr(cache, "get_sources", lambda: [source])
+    monkeypatch.setattr(
+        gateway_catalog,
+        "fetch_source_live_data",
+        lambda _source, **_kwargs: (
+            [],
+            [{"stream_id": 7, "name": "Uncategorized", "category_ids": []}],
+            None,
+            120,
+        ),
+    )
+    snapshot = GatewayCatalog(
+        registry=StreamIdRegistry(tmp_path / "ids.json"),
+        ttl_seconds=60,
+    ).get()
+
+    category_id = snapshot.categories[0]["category_id"]
+    assert category_id.isdigit()
+    assert snapshot.streams[0].public["category_id"] == category_id
+    assert snapshot.streams[0].public["category_ids"] == [category_id]
+
+
+def test_m3u_registry_key_uses_url_instead_of_playlist_position(tmp_path: Path):
+    catalog = GatewayCatalog(
+        registry=StreamIdRegistry(tmp_path / "ids.json"),
+        ttl_seconds=60,
+    )
+    first = catalog._stream_registry_key(
+        "source-a",
+        "m3u",
+        {
+            "stream_id": "source-a_1",
+            "direct_url": "https://streams.example/news?token=first",
+            "epg_channel_id": "news.example",
+            "name": "News",
+        },
+    )
+    reordered = catalog._stream_registry_key(
+        "source-a",
+        "m3u",
+        {
+            "stream_id": "source-a_42",
+            "direct_url": "https://streams.example/news?token=rotated",
+            "epg_channel_id": "news.example",
+            "name": "News",
+        },
+    )
+    different = catalog._stream_registry_key(
+        "source-a",
+        "m3u",
+        {
+            "stream_id": "source-a_1",
+            "direct_url": "https://streams.example/sports",
+            "epg_channel_id": "sports.example",
+            "name": "Sports",
+        },
+    )
+
+    assert first == reordered
+    assert first != different
+
+
+def test_catalog_assigns_distinct_ids_to_colliding_m3u_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source = SimpleNamespace(
+        id="source-a",
+        name="Provider",
+        type="m3u",
+        epg_enabled=False,
+    )
+    monkeypatch.setattr(cache, "get_sources", lambda: [source])
+    monkeypatch.setattr(
+        gateway_catalog,
+        "fetch_source_live_data",
+        lambda _source, **_kwargs: (
+            [],
+            [
+                {
+                    "stream_id": "source-a_1",
+                    "name": "News",
+                    "direct_url": "https://streams.example/play?id=1",
+                    "category_ids": [],
+                },
+                {
+                    "stream_id": "source-a_2",
+                    "name": "News",
+                    "direct_url": "https://streams.example/play?id=2",
+                    "category_ids": [],
+                },
+            ],
+            None,
+            120,
+        ),
+    )
+
+    snapshot = GatewayCatalog(
+        registry=StreamIdRegistry(tmp_path / "ids.json"),
+        ttl_seconds=60,
+    ).get()
+
+    assert len(snapshot.streams) == 2
+    assert len(snapshot.streams_by_id) == 2
+    assert snapshot.streams[0].local_id != snapshot.streams[1].local_id
+
+
+def test_catalog_retains_previous_snapshot_when_refresh_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source = SimpleNamespace(
+        id="source-a",
+        name="Provider",
+        type="xtream",
+        epg_enabled=False,
+    )
+    monkeypatch.setattr(cache, "get_sources", lambda: [source])
+    source_data = (
+        [{"category_id": "source-a_9", "category_name": "News", "parent_id": 0}],
+        [{"stream_id": 7, "name": "News", "category_ids": ["source-a_9"]}],
+        None,
+        120,
+    )
+    fetch = MagicMock(return_value=source_data)
+    monkeypatch.setattr(gateway_catalog, "fetch_source_live_data", fetch)
+    catalog = GatewayCatalog(
+        registry=StreamIdRegistry(tmp_path / "ids.json"),
+        ttl_seconds=60,
+    )
+    original = catalog.get()
+    fetch.side_effect = urllib.error.URLError("temporary failure")
+
+    refreshed = catalog.get(force=True)
+
+    assert refreshed is original
+    assert len(refreshed.streams) == 1
+
+
+def test_playlist_accepts_mpegts_output(gateway_client):
+    client, _ = gateway_client
+    response = client.get(
+        "/get.php",
+        params={
+            "username": "player",
+            "password": "local-pass",
+            "output": "mpegts",
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_live_stream_password_may_contain_slash(
+    gateway_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client, _ = gateway_client
+    upstream = MagicMock()
+    upstream.headers = {"Content-Type": "video/mp2t"}
+    upstream.read.side_effect = [b"video-data", b""]
+    monkeypatch.setattr(
+        gateway.authenticator,
+        "verify",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(gateway, "_resolve_upstream", lambda _stream, _extension: "http://upstream")
+    monkeypatch.setattr(gateway, "safe_urlopen", MagicMock(return_value=upstream))
+
+    response = client.get("/live/player/local%2Fpass/41.ts")
+
+    assert response.status_code == 200
+    assert response.content == b"video-data"

--- a/m3u.py
+++ b/m3u.py
@@ -156,7 +156,10 @@ def _fetch_all_live_data() -> tuple[list[dict], list[dict], list[tuple[str, int,
     return all_categories, all_streams, epg_urls
 
 
-def fetch_source_live_data(source: Any) -> tuple[list[dict], list[dict], str | None, int]:
+def fetch_source_live_data(
+    source: Any,
+    persist_epg_url: bool = True,
+) -> tuple[list[dict], list[dict], str | None, int]:
     """Fetch live data for a single source. Returns (cats, streams, epg_url, epg_timeout)."""
     cats: list[dict] = []
     streams: list[dict] = []
@@ -178,11 +181,13 @@ def fetch_source_live_data(source: Any) -> tuple[list[dict], list[dict], str | N
             orig_cats = s.get("category_ids") or [s.get("category_id")]
             s["category_ids"] = [f"{source.id}_{c}" for c in orig_cats if c]
         detected_epg = client.epg_url
-        update_source_epg_url(source.id, detected_epg)
+        if persist_epg_url:
+            update_source_epg_url(source.id, detected_epg)
         epg_url = detected_epg if source.epg_enabled else None
     elif source.type == "m3u":
         cats, streams, detected_epg = fetch_m3u(source.url, source.id)
-        update_source_epg_url(source.id, detected_epg)
+        if persist_epg_url:
+            update_source_epg_url(source.id, detected_epg)
         epg_url = detected_epg if source.epg_enabled else None
     elif source.type == "epg":
         epg_url = source.url

--- a/m3u_test.py
+++ b/m3u_test.py
@@ -149,6 +149,32 @@ class TestMakeClientUserAgent:
         assert mock_open.call_args.kwargs["user_agent"] == cache.USER_AGENT_PRESETS["vlc"]
 
 
+class TestFetchSourceLiveData:
+    def test_can_skip_epg_url_persistence(self, m3u_module):
+        source = SimpleNamespace(
+            id="source-a",
+            name="Provider",
+            type="xtream",
+            url="https://provider.example",
+            username="remote-user",
+            password="remote-password",
+            epg_enabled=True,
+            epg_timeout=120,
+        )
+        client = MagicMock()
+        client.get_live_categories.return_value = []
+        client.get_live_streams.return_value = []
+        client.epg_url = "https://provider.example/xmltv.php?credentials=private"
+
+        with (
+            patch.object(m3u_module, "_make_client", return_value=client),
+            patch.object(m3u_module, "update_source_epg_url") as update_epg_url,
+        ):
+            m3u_module.fetch_source_live_data(source, persist_epg_url=False)
+
+        update_epg_url.assert_not_called()
+
+
 if __name__ == "__main__":
     from testing import run_tests
 

--- a/util.py
+++ b/util.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+import json
+import os
+import pathlib
+import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -28,6 +32,29 @@ class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 
 _DEFAULT_USER_AGENT = "VLC/3.0.20 LibVLC/3.0.20"
+
+
+def atomic_write_json(path: pathlib.Path, value: Any) -> None:
+    """Atomically replace a JSON file while preserving existing permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: pathlib.Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temp:
+            json.dump(value, temp, indent=2)
+            temp.flush()
+            if path.exists():
+                os.fchmod(temp.fileno(), path.stat().st_mode & 0o777)
+            os.fsync(temp.fileno())
+            temp_path = pathlib.Path(temp.name)
+        temp_path.replace(path)
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
 
 
 def safe_urlopen(url: str, timeout: int = 30, user_agent: str | None = None) -> Any:

--- a/util_test.py
+++ b/util_test.py
@@ -4,11 +4,25 @@ from __future__ import annotations
 
 from typing import Any
 
+import json
+import pathlib
 import urllib.error
 
 import pytest
 
 import util
+
+
+def test_atomic_write_json_replaces_file_and_preserves_permissions(tmp_path: pathlib.Path):
+    path = tmp_path / "settings.json"
+    path.write_text('{"old": true}')
+    path.chmod(0o640)
+
+    util.atomic_write_json(path, {"new": True})
+
+    assert json.loads(path.read_text()) == {"new": True}
+    assert path.stat().st_mode & 0o777 == 0o640
+    assert list(tmp_path.iterdir()) == [path]
 
 
 def _fake_request(url: str) -> Any:


### PR DESCRIPTION
## Summary

- add a standalone Xtream-compatible live-TV gateway on port 8100 while leaving the existing web UI on port 8000
- expose live categories, streams, M3U playlists, short EPG data, MPEG-TS passthrough, and user-filtered XMLTV
- preserve stable numeric stream/category IDs and enforce neTV user category restrictions across every gateway surface
- add an architecture-neutral gateway image and align shared-volume users across the web, gateway, and AI-upscale images

## Details

Native IPTV players authenticate with a dedicated neTV user account. Provider credentials and playback URLs remain private, while player-facing URLs stay local to the gateway. The gateway accepts both `ts` and `mpegts` output modes and supports slash-containing passwords for live playback URLs.

XMLTV is generated from the shared EPG database and includes only channels visible to the authenticated user. This avoids sending the provider's complete guide to restricted users and substantially reduces guide downloads.

Authentication failures are rate-limited, password verification runs outside the async event loop, forwarded client addresses are trusted only from explicitly configured proxies, and settings/ID registry writes use atomic replacement.

## Current scope

- live TV only; VOD and series actions return empty results
- playback is provider passthrough and is not upscaled yet
- provider connection counts are not coordinated with the web process
- the gateway currently fetches provider catalogs independently
- default Compose retains `/dev/dri` for Linux acceleration; macOS requires an override that removes that device mapping

## Validation

- 419 tests passed
- Ruff passed
- basedpyright passed
- Compose configuration validated
- web and gateway images built on Apple Silicon with `FFMPEG_IMAGE=ubuntu:24.04`
- rebuilt services responded on ports 8000 and 8100
